### PR TITLE
Simplify test deps round 2

### DIFF
--- a/bripipetools/annotation/flowcellruns.py
+++ b/bripipetools/annotation/flowcellruns.py
@@ -23,7 +23,7 @@ class FlowcellRunAnnotator(object):
                      .format(run_id))
         self.run_id = run_id
         self.db = db
-        self.flowcellrun = self._init_flowcellrun()
+        # self.flowcellrun = self._init_flowcellrun()
 
         logger.debug("setting 'genomics' path")
         self.genomics_path = os.path.join(genomics_root, 'genomics')
@@ -63,7 +63,11 @@ class FlowcellRunAnnotator(object):
         """
         logger.info("searching for 'Unaligned' folder")
         try:
-            return os.path.join(self._get_flowcell_path(), 'Unaligned')
+            unaligned_path = os.path.join(self._get_flowcell_path(),
+                                          'Unaligned')
+            if not os.path.exists(unaligned_path):
+                raise OSError
+            return unaligned_path
         except OSError:
             logger.error("'Unaligned' folder doesn't exist")
             raise

--- a/bripipetools/annotation/flowcellruns.py
+++ b/bripipetools/annotation/flowcellruns.py
@@ -23,7 +23,7 @@ class FlowcellRunAnnotator(object):
                      .format(run_id))
         self.run_id = run_id
         self.db = db
-        # self.flowcellrun = self._init_flowcellrun()
+        self.flowcellrun = self._init_flowcellrun()
 
         logger.debug("setting 'genomics' path")
         self.genomics_path = os.path.join(genomics_root, 'genomics')

--- a/bripipetools/annotation/processedlibs.py
+++ b/bripipetools/annotation/processedlibs.py
@@ -25,6 +25,7 @@ class ProcessedLibraryAnnotator(object):
         self.proclib_id = '{}_processed'.format(self.seqlib_id)
         self.processedlibrary = self._init_processedlibrary()
 
+    # TODO: move to parsing module
     def _get_seqlib_id(self):
         """
         Return the ID of the parent sequenced library.
@@ -54,17 +55,24 @@ class ProcessedLibraryAnnotator(object):
         return {p['tag']: p['value'] for p in self.params
                 if p['type'] == 'output' and p['name'] == 'to_path'}
 
+    # TODO: move to parsing module
     def _parse_output_name(self, output_name):
         """
         Parse output name indicated by parameter tag in workflow batch
         submit file and return individual components indicating name,
         source, and type.
         """
-        name = re.sub('_out', '', output_name)
+        name = re.sub('_out$', '', output_name)
         name_parts = name.split('_')
-        file_format = name_parts.pop(-1)
-        output_type = name_parts.pop(-1)
-        source = '_'.join(name_parts)
+        logger.debug("{}".format(name_parts))
+        if len(name_parts) == 3:
+            name = '_'.join(name_parts)
+            output_type = name_parts[1]
+            source = name_parts[0]
+        else:
+            # to handle old style tags
+            output_type = name_parts.pop(-1)
+            source = '_'.join(name_parts)
 
         return {'name': name, 'type': output_type, 'source': source}
 

--- a/bripipetools/dbify/__init__.py
+++ b/bripipetools/dbify/__init__.py
@@ -7,6 +7,6 @@ bioinformatics processing of a batch of samples). The ``dbify.control``
 submodule inspects an input path and deplys the appropriate importer
 class.
 """
-from .sequencing import SequencingImporter
+from .flowcellrun import FlowcellRunImporter
 from .processing import ProcessingImporter
 from .control import ImportManager

--- a/bripipetools/dbify/__init__.py
+++ b/bripipetools/dbify/__init__.py
@@ -8,5 +8,5 @@ submodule inspects an input path and deplys the appropriate importer
 class.
 """
 from .flowcellrun import FlowcellRunImporter
-from .processing import ProcessingImporter
+from .workflowbatch import WorkflowBatchImporter
 from .control import ImportManager

--- a/bripipetools/dbify/control.py
+++ b/bripipetools/dbify/control.py
@@ -21,9 +21,8 @@ class ImportManager(object):
                      .format(path, db.name))
         self.path = path
         self.db = db
-        self._init_importer()
 
-    def _sniff_path(self, path):
+    def _sniff_path(self):
         """
         Check path for known patterns and return path type for importer.
         """
@@ -32,13 +31,13 @@ class ImportManager(object):
             'workflowbatch_file': re.compile('batch_submission.*\.txt$')
         }
         return [k for k, v in path_types.items()
-                if v.search(path.rstrip('/'))][0]
+                if v.search(self.path.rstrip('/'))][0]
 
     def _init_importer(self):
         """
         Initialize the appropriate importer for the provided path.
         """
-        path_type = self._sniff_path(self.path)
+        path_type = self._sniff_path()
         importer_opts = {
             'flowcell_path': FlowcellRunImporter,
             'workflowbatch_file': WorkflowBatchImporter
@@ -50,4 +49,5 @@ class ImportManager(object):
         """
         Execute the insert method of the selected importer.
         """
+        self._init_importer()
         self.importer.insert()

--- a/bripipetools/dbify/control.py
+++ b/bripipetools/dbify/control.py
@@ -4,7 +4,7 @@ Parse arguments to determine and select appropriate importer class.
 import logging
 import re
 
-from . import SequencingImporter, ProcessingImporter
+from . import FlowcellRunImporter, ProcessingImporter
 
 logger = logging.getLogger(__name__)
 

--- a/bripipetools/dbify/control.py
+++ b/bripipetools/dbify/control.py
@@ -4,7 +4,7 @@ Parse arguments to determine and select appropriate importer class.
 import logging
 import re
 
-from . import FlowcellRunImporter, ProcessingImporter
+from . import FlowcellRunImporter, WorkflowBatchImporter
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +40,8 @@ class ImportManager(object):
         """
         path_type = self._sniff_path(self.path)
         importer_opts = {
-            'flowcell_path': SequencingImporter,
-            'workflowbatch_file': ProcessingImporter
+            'flowcell_path': FlowcellRunImporter,
+            'workflowbatch_file': WorkflowBatchImporter
         }
         importer = importer_opts[path_type]
         self.importer = importer(path=self.path, db=self.db)

--- a/bripipetools/dbify/flowcellrun.py
+++ b/bripipetools/dbify/flowcellrun.py
@@ -11,7 +11,7 @@ from .. import annotation
 logger = logging.getLogger(__name__)
 
 
-class SequencingImporter(object):
+class FlowcellRunImporter(object):
     """
     Collects FlowcellRun and SequencedLibrary objects from a sequencing run,
     converts to documents, inserts into database.

--- a/bripipetools/dbify/workflowbatch.py
+++ b/bripipetools/dbify/workflowbatch.py
@@ -11,7 +11,7 @@ from .. import annotation
 logger = logging.getLogger(__name__)
 
 
-class ProcessingImporter(object):
+class WorkflowBatchImporter(object):
     """
     Collects WorkflowBatch and ProcessedLibrary objects from a processing
     batch, converts to documents, inserts into database.

--- a/bripipetools/parsing/__init__.py
+++ b/bripipetools/parsing/__init__.py
@@ -10,4 +10,4 @@ Depends on the ``util`` module.
 """
 from .illumina import (get_project_label, parse_project_label,
                        get_library_id, get_flowcell_id, parse_flowcell_run_id,
-                       parse_fastq_filename)
+                       parse_fastq_filename, parse_batch_name)

--- a/bripipetools/parsing/illumina.py
+++ b/bripipetools/parsing/illumina.py
@@ -131,3 +131,17 @@ def parse_fastq_filename(path):
 
     return {'path': path, 'lane_id': lane_id, 'read_id': read_id,
             'sample_number': sample_num}
+
+
+def parse_batch_name(batch_name):
+    """
+    Parse batch name indicated in workflow batch submit file and
+    return individual components indicating date, list of project
+    labels, and flowcell ID.
+    """
+    name_parts = batch_name.split('_')
+    date = datetime.datetime.strptime(name_parts.pop(0), '%y%m%d')
+
+    fc_id = name_parts.pop(-1)
+
+    return {'date': date, 'projects': name_parts, 'flowcell_id': fc_id}

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -51,8 +51,9 @@ class OutputCleaner(object):
         paths = []
         with zipfile.ZipFile(path) as zf:
             logger.debug("zip folder contents: {}".format(zf.namelist()))
-            for f in zf.namelist()[1:]:
-                paths.append(zf.extract(f, os.path.dirname(path)))
+            for f in zf.namelist():
+                if f != './':
+                    paths.append(zf.extract(f, os.path.dirname(path)))
         logging.debug("unzipped the following files: {}".format(paths))
         return paths
 

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -35,7 +35,7 @@ class OutputCleaner(object):
         """
         Return full path for individual output files.
         """
-        logging.debug("locating output files of type {}".format(output_type))
+        logging.debug("locating output files of type '{}'".format(output_type))
         output_root = os.path.join(self.path, output_type)
         return [os.path.join(self.path, root, f)
                 for root, dirs, files in os.walk(output_root)

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -50,6 +50,7 @@ class OutputCleaner(object):
                       .format(path, os.path.dirname(path)))
         paths = []
         with zipfile.ZipFile(path) as zf:
+            logger.debug("zip folder contents: {}".format(zf.namelist()))
             for f in zf.namelist()[1:]:
                 paths.append(zf.extract(f, os.path.dirname(path)))
         logging.debug("unzipped the following files: {}".format(paths))

--- a/bripipetools/postprocess/compiling.py
+++ b/bripipetools/postprocess/compiling.py
@@ -45,7 +45,7 @@ class OutputCompiler(object):
         """
         Modify input path to create filename for combined CSV file.
         """
-        return re.sub('(?<=combined_)\w*', 'summary_data',
+        return re.sub('(?<=combined_)\w*', 'summary-data',
                       os.path.basename(self.paths[0]))
 
     def write_table(self):
@@ -59,7 +59,7 @@ class OutputCompiler(object):
                                   self._build_combined_filename())
         logger.debug("writing to file {}".format(table_path))
         with open(table_path, 'w') as f:
-            writer = csv.writer(f)
+            writer = csv.writer(f, lineterminator='\n')
             for row in table_data:
                 writer.writerow(row)
         return table_path

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -7,12 +7,14 @@ import datetime
 
 import pytest
 import mongomock
+import mock
 
 from bripipetools import model as docs
 from bripipetools import io
 from bripipetools import annotation
 
-@pytest.fixture(scope='class')
+
+@pytest.fixture(scope='function')
 def mock_db(request):
     logger.info(("[setup] mock database, connect "
                  "to mock Mongo database"))
@@ -24,801 +26,1041 @@ def mock_db(request):
     request.addfinalizer(fin)
     return db
 
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+
 class TestFlowcellRunAnnotator:
     """
     Tests methods for the `FlowcellRunAnnotator` class in the
-    `bripipetools.annotation.illuminaseq` module.
+    `bripipetools.annotation.flowcellruns` module.
     """
-    @pytest.fixture(scope='class', params=[{'runnum': r} for r in range(1)])
-    def annotatordata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a FlowcellRunAnnotator with mock 'genomics' server path,
-        # valid run ID, and existing 'Unaligned' folder (i.e., where data
-        # and organization is known), as well as a mock db connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
+    # @pytest.fixture(scope='class', params=[{'runnum': r} for r in range(1)])
+    # def annotatordata(self, request, mock_genomics_server, mock_db):
+    #     # GIVEN a FlowcellRunAnnotator with mock 'genomics' server path,
+    #     # valid run ID, and existing 'Unaligned' folder (i.e., where data
+    #     # and organization is known), as well as a mock db connection
+    #     runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+    #     rundata = runs[request.param['runnum']]
+    #
+    #     logger.info("[setup] FlowcellRunAnnotator test instance "
+    #                 "for run {}".format(rundata['run_id']))
+    #
+    #     fcrunannotator = annotation.FlowcellRunAnnotator(
+    #         run_id=rundata['run_id'],
+    #         db=mock_db,
+    #         genomics_root=mock_genomics_server['root']['path'])
+    #
+    #     def fin():
+    #         logger.info("[teardown] FlowcellRunAnnotator mock instance")
+    #     request.addfinalizer(fin)
+    #     return (fcrunannotator, rundata)
 
-        logger.info("[setup] FlowcellRunAnnotator test instance "
-                    "for run {}".format(rundata['run_id']))
-
-        fcrunannotator = annotation.FlowcellRunAnnotator(
-            run_id=rundata['run_id'],
-            db=mock_db,
-            genomics_root=mock_genomics_server['root']['path'])
-
-        def fin():
-            logger.info("[teardown] FlowcellRunAnnotator mock instance")
-        request.addfinalizer(fin)
-        return (fcrunannotator, rundata)
-
-    def test_init_flowcellrun_existing_run(self, annotatordata, mock_db):
-        # (GIVEN)
-        (annotator, rundata) = annotatordata
-
-        logger.info("test `_init_flowcellrun()` with existing run")
-
-        # WHEN flowcell run already exists in 'runs' collection
+    def test_init_flowcellrun_for_existing_run(self, mock_db):
+        # GIVEN a flowcell run ID and a connection to a database in which
+        # a document corresponding to the flowcell run exists already
+        testid = '161231_INSTID_0001_AC00000XX'
         mock_db.runs.insert_one(
-            {'_id': rundata['run_id'],
-             'type': 'flowcell',
-             'isMock': True})
-        flowcellrun = annotator._init_flowcellrun()
+            {'_id': testid,
+             'type': 'flowcell'}
+        )
+
+        # AND an annotator object is created for the flowcell run with
+        # an arbitrary 'genomics' root specified
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root='/mnt'
+        )
+
+        # WHEN the model object is initiated for the annotator
+        modelobject = annotator._init_flowcellrun()
 
         # THEN the flowcell run object should be returned and
         # should be correctly mapped from the database object
-        assert(type(flowcellrun) == docs.FlowcellRun)
-        assert(flowcellrun._id == rundata['run_id'])
-        assert(hasattr(flowcellrun, 'is_mock'))
+        assert (type(modelobject) == docs.FlowcellRun)
+        assert (modelobject._id == testid)
+        assert modelobject.is_mapped
 
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.runs.drop()
+    def test_init_flowcellrun_for_new_run(self, mock_db):
+        # GIVEN a flowcell run ID and a connection to a database in which
+        # a document corresponding to the flowcell run does not exist
+        testid = '161231_INSTID_0001_AC00000XX'
 
-    def test_init_flowcellrun_new_run(self, annotatordata):
-        # (GIVEN)
-        annotator, rundata = annotatordata
+        # AND an annotator object is created for the flowcell run with
+        # an arbitrary 'genomics' root specified
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root='/mnt'
+        )
 
-        logger.info("test `_init_flowcellrun()` with new run")
+        # WHEN the model object is initiated for the annotator
+        modelobject = annotator._init_flowcellrun()
 
-        # WHEN flowcell run run does not already exist in
-        # 'runs' collection
-        flowcellrun = annotator._init_flowcellrun()
+        # THEN the new flowcell run object should be returned
+        assert (type(modelobject) == docs.FlowcellRun)
+        assert (modelobject._id == testid)
+        assert not modelobject.is_mapped
 
-        # THEN a new flowcell run object should be returned
-        assert(type(flowcellrun) == docs.FlowcellRun)
-        assert(flowcellrun._id == rundata['run_id'])
-        assert(not hasattr(flowcellrun, 'is_mock'))
-#
-    def test_get_flowcell_path(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, rundata = annotatordata
+    def test_get_flowcell_path_for_existing_folder(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at the path 'genomics/Illumina/<run_id>'
+        testid = '161231_INSTID_0001_AC00000XX'
+        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
 
-        logger.info("test `_get_flowcell_path()`")
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
 
-        # WHEN searching for flowcell run ID in 'genomics' path
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN the flowcell folder path is retrieved
+        testpath = annotator._get_flowcell_path()
 
         # THEN correct flowcell folder should be found in 'genomics/Illumina/'
-        assert(annotator._get_flowcell_path() == rundata['path'])
+        assert (testpath == str(mockpath))
 
-    def test_get_unaligned_path(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, rundata = annotatordata
+    def test_get_flowcell_path_for_invalid_root(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary directory that does not
+        # contain 'genomics/Illumina/'
+        testid = '161231_INSTID_0001_AC00000XX'
 
-        logger.info("test `_get_unaligned_path()`")
-
-        # WHEN searching for 'Unaligned' folder
-
-        # THEN path returned should be 'genomics/Illumina/<run_id>/Unaligned'
-        assert(annotator._get_unaligned_path() == rundata['unaligned']['path'])
-
-    def test_get_projects(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, rundata = annotatordata
-
-        logger.info("test `_get_projects()`")
-
-        # WHEN listing unaligned projects
-        projects = annotator.get_projects()
-
-        # THEN should find expected number of projects
-        assert(len(projects) == len(rundata['unaligned']['projects']))
-
-    @pytest.mark.parametrize("projectnum", [0, 1, 2])
-    def test_get_libraries_single_project(self, annotatordata,
-                                          mock_genomics_server, projectnum):
-        # (GIVEN)
-        annotator, rundata = annotatordata
-
-        # AND unaligned samples for a single project
-        projectdata = rundata['unaligned']['projects'][projectnum]
-
-        logger.info("test `_get_libraries()`, single project ({})"
-                    .format(projectdata['name']))
-
-        # WHEN listing libraries for the project
-        libraries = annotator.get_libraries(projectdata['name'])
-
-        # THEN should find the expected number of libaries (samples)
-        assert(len(libraries) == len(projectdata['samples']))
-
-    def test_get_libraries_all_projects(self, annotatordata,
-                                        mock_genomics_server):
-        # (GIVEN)
-        annotator, rundata = annotatordata
-
-        # AND list of unaligned projects
-        projects = rundata['unaligned']['projects']
-
-        logger.info("test `_get_libraries()`, all projects")
-
-        # WHEN listing libraries for all projects
-        libraries = annotator.get_libraries()
-
-        # THEN should find expected number of libraries
-        assert(len(libraries)
-                == sum(map(lambda x: len(x['samples']), projects)))
-
-    @pytest.mark.parametrize("projectnum", [0, 1, 2])
-    def test_get_sequenced_libraries_single_project(self, annotatordata,
-                                                    mock_genomics_server,
-                                                    projectnum):
-        # (GIVEN)
-        annotator, rundata = annotatordata
-
-        # AND unaligned samples for a single project
-        projectdata = rundata['unaligned']['projects'][projectnum]
-
-        logger.info("test `get_sequenced_libraries()`, single project ({})"
-                    .format(projectdata['name']))
-
-        # WHEN collecting sequenced libraries for project
-        sequencedlibraries = annotator.get_sequenced_libraries(
-            projectdata['name'])
-
-        # THEN should find excpeted number of sequenced libraries
-        assert(len(sequencedlibraries) == len(projectdata['samples']))
-
-    def test_get_sequenced_libraries_all_projects(self, annotatordata,
-                                                  mock_genomics_server):
-        # (GIVEN)
-        annotator, rundata = annotatordata
-
-        # AND list of unaligned projects
-        projects = rundata['unaligned']['projects']
-
-        logger.info("test `get_sequenced_libraries()`, all projects")
-
-        # WHEN collecting sequenced libraries for all projects
-        sequencedlibraries = annotator.get_sequenced_libraries()
-
-        # THEN should find 31 total libraries
-        assert(len(sequencedlibraries)
-               == sum(map(lambda x: len(x['samples']), projects)))
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestSequencedLibraryAnnotator:
-    """
-    Tests methods for the `SequencedLibraryAnnotator` class in the
-    `bripipetools.annotation.illuminaseq` module.
-    """
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'projectnum': p, 'samplenum': s}
-                for r in range(1)
-                for p in range(3)
-                for s in range(3)])
-    def annotatordata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a SequencedLibraryAnnotator with mock 'genomics' server path,
-        # and path to library folder (i.e., where data/organization is known),
-        # with specified library, project, and run ID, as well as a mock
-        # db connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        projects = rundata['unaligned']['projects']
-        projectdata = projects[request.param['projectnum']]
-        samples = projectdata['samples']
-        sampledata = samples[request.param['samplenum']]
-
-        logger.info("[setup] SequencedLibraryAnnotator mock instance "
-                    " for sample {} in project {} from run {}"
-                    .format(sampledata['name'], projectdata['name'],
-                            rundata['flowcell_id']))
-
-        seqlibannotator = annotation.SequencedLibraryAnnotator(
-            path=sampledata['path'],
-            library=os.path.basename(sampledata['path']),
-            project=os.path.basename(projectdata['path']),
-            run_id=rundata['run_id'],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] SequencedLibraryAnnotator mock instance")
-        request.addfinalizer(fin)
-        return (seqlibannotator, rundata, sampledata)
-
-    def test_init_attribute_munging(self, annotatordata):
-        # (GIVEN)
-        annotator, rundata, sampledata = annotatordata
-        seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
-
-        logger.info("test `__init__()` for proper attribute munging")
-
-        # WHEN checking whether input arguments were automatically munged
-        # when setting annotator attributes
-
-        # THEN the sequenced library ID should be properly constructed as the
-        # library ID and flowcell ID
-        assert(annotator.seqlib_id == seqlib_id)
-
-    def test_init_sequencedlibrary_existing_sample(self, annotatordata,
-                                                   mock_db):
-        # (GIVEN)
-        annotator, rundata, sampledata = annotatordata
-        seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
-
-        logger.info("test `_init_sequencedlibrary()` with existing sample {}"
-                    .format(seqlib_id))
-
-        # WHEN sequenced library already exists in 'samples' collection
-        mock_db.samples.insert_one(
-            {'_id': seqlib_id,
-             'type': 'sequenced library',
-             'isMock': True})
-        sequencedlibrary = annotator._init_sequencedlibrary()
-
-        # THEN the sequenced library object should be returned and
-        # should be correctly mapped from the database object
-        assert(type(sequencedlibrary) == docs.SequencedLibrary)
-        assert(sequencedlibrary._id == seqlib_id)
-        assert(hasattr(sequencedlibrary, 'is_mock'))
-
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.samples.drop()
-
-    def test_init_sequencedlibrary_new_sample(self, annotatordata):
-        # (GIVEN)
-        annotator, rundata, sampledata = annotatordata
-        seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
-
-        logger.info("test `_init_sequencedlibrary()` with new sample {}"
-                    .format(seqlib_id))
-
-        # WHEN sequenced library sample does not already exist in
-        # 'samples' collection
-        sequencedlibrary = annotator._init_sequencedlibrary()
-
-        # THEN a new sequenced library object should be returned
-        assert(type(sequencedlibrary) == docs.SequencedLibrary)
-        assert(sequencedlibrary._id == seqlib_id)
-        assert(not hasattr(sequencedlibrary, 'is_mock'))
-
-    def test_get_raw_data(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, _, sampledata = annotatordata
-
-        logger.info("test `_get_raw_data()` for sample {}"
-                    .format(sampledata['name']))
-
-        # WHEN collecting raw data for a sequenced library
-        raw_data = annotator._get_raw_data()
-
-        # THEN should be a list of dicts, with the correct details for each
-        # FASTQ file identified
-        assert(set(f['path'] for f in raw_data)
-                == set(f for f in os.listdir(sampledata['path'])
-                       if not re.search('empty', f)))
-
-    def test_update_sequencedlibrary(self, annotatordata):
-        # (GIVEN)
-        annotator, _, sampledata = annotatordata
-
-        logger.info("test `_update_sequencedlibrary()` for sample {}"
-                    .format(sampledata['name']))
-
-        # WHEN sequenced library object is updated
-        annotator._update_sequencedlibrary()
-
-        # THEN the object should have at least the 'run_id', 'project_id',
-        # 'subproject_id', 'parent_id' and 'raw_data' attributes
-        assert(all([hasattr(annotator.sequencedlibrary, field)
-                    for field in ['run_id', 'project_id', 'subproject_id',
-                                  'parent_id', 'raw_data', 'date_created',
-                                  'last_updated']]))
-        assert(annotator.sequencedlibrary.last_updated
-               > annotator.sequencedlibrary.date_created)
-
-    def test_get_sequenced_library(self, annotatordata):
-        # (GIVEN)
-        annotator, _, sampledata = annotatordata
-
-        logger.info("test `get_sequenced_library()` for sample {}"
-                    .format(sampledata['name']))
-
-        # WHEN sequenced library object is returned
-        sequencedlibrary = annotator.get_sequenced_library()
-
-        # THEN the object should be of type SequencedLibrary and have
-        # at least the 'run_id', 'project_id', 'subproject_id', 'parent_id',
-        # and 'raw_data' attributes
-        assert(type(sequencedlibrary) is docs.SequencedLibrary)
-        assert(all([hasattr(sequencedlibrary, field)
-                    for field in ['run_id', 'project_id', 'subproject_id',
-                                  'parent_id', 'raw_data']]))
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestWorkflowBatchAnnotator:
-    """
-    Tests methods for the `WorkflowBatchAnnotator` class in the
-    `bripipetools.annotation.globusgalaxy` module.
-    """
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'batchnum': b}
-                for r in range(1)
-                for b in range(2)])
-    @pytest.fixture(scope='class')
-    def annotatordata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a WorkflowBatchAnnotator with mock 'genomics' server path,
-        # and path to workflow batch file with specified genomics root,
-        # as well as a mock db connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        batches = rundata['submitted']['batches']
-        batchdata = batches[request.param['batchnum']]
-
-        logger.info("[setup] WorkflowBatchAnnotator mock instance "
-                    "for batch {}".format(os.path.basename(batchdata['path'])))
-
-        wflowbatchannotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=batchdata['path'],
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
             db=mock_db,
-            genomics_root=mock_genomics_server['root']['path'])
+            genomics_root=str(tmpdir)
+        )
 
-        def fin():
-            logger.info("[teardown] WorkflowBatchAnnotator mock instance")
-        request.addfinalizer(fin)
-        return (wflowbatchannotator, batchdata)
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
 
-    def test_init_file_parsing(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
+        # WHEN the flowcell folder path is retrieved
 
-        logger.info("test `__init__()` for proper file parsing "
-                    "with batch {}"
-                    .format(os.path.basename(batchdata['path'])))
+        # THEN should raise expected exception
+        with pytest.raises(OSError):
+            annotator._get_flowcell_path()
 
-        # WHEN checking whether input arguments were automatically munged
-        # when setting annotator attributes
-        workflowbatch_data = annotator.workflowbatch_data
+    def test_get_unaligned_path_for_existing_folder(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at 'genomics/Illumina/<run_id>',
+        # and that folder contains a subfolder named 'Unaligned'
+        testid = '161231_INSTID_0001_AC00000XX'
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+                    .mkdir('Unaligned'))
 
-        # THEN the workflow batch data should be a dictionary with fields for
-        # workflow name, parameters, and samples
-        assert(workflowbatch_data['workflow_name'] == batchdata['workflow'])
-        assert(len(workflowbatch_data['parameters']) == batchdata['num_params'])
-        assert(len(workflowbatch_data['samples']) == batchdata['num_samples'])
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN the flowcell folder path is retrieved
+        testpath = annotator._get_unaligned_path()
+
+        # THEN correct flowcell folder should be found in 'genomics/Illumina/'
+        assert (testpath == str(mockpath))
+
+    def test_get_unaligned_path_for_missing_folder(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at 'genomics/Illumina/<run_id>',
+        # and there is no subfolder named 'Unaligned'
+        testid = '161231_INSTID_0001_AC00000XX'
+        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN the unaligned folder path is retrieved
+
+        # THEN should raise expected exception
+        with pytest.raises(OSError):
+            annotator._get_unaligned_path()
+
+    def test_get_flowcell_run(self, mock_db):
+        # GIVEN any state and a flowcell run annotator object
+        testid = '161231_INSTID_0001_AC00000XX'
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root='/mnt'
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN model object is retrieved
+        testobject = annotator.get_flowcell_run()
+
+        # THEN should be expected object
+        assert (testobject == mockobject)
+
+    def test_get_projects(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at 'genomics/Illumina/<run_id>',
+        # and that folder contains a subfolder named 'Unaligned'
+        testid = '161231_INSTID_0001_AC00000XX'
+        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+                    .mkdir('Unaligned'))
+        for p in mockprojects:
+            mockpath.mkdir(p)
+
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN list of projects is retrieved
+        testprojects = annotator.get_projects()
+
+        # THEN
+        assert (testprojects == mockprojects)
+
+    def test_get_libraries(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at 'genomics/Illumina/<run_id>',
+        # and that folder contains a subfolder named 'Unaligned'
+        testid = '161231_INSTID_0001_AC00000XX'
+        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
+        mocklibs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+                    1: ['lib3333-33333333', 'lib4444-44444444']}
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+                    .mkdir('Unaligned'))
+        for idx, p in enumerate(mockprojects):
+            projpath = mockpath.mkdir(p)
+            for l in mocklibs[idx]:
+                projpath.mkdir(l)
+
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=testid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = testid
+        annotator.flowcellrun = mockobject
+
+        # WHEN list of projects is retrieved
+        testlibs = annotator.get_libraries()
+
+        # THEN
+        assert (testlibs == [l for libs in mocklibs.values() for l in libs])
+
+#     def test_init_flowcellrun_existing_run(self, annotatordata, mock_db):
+#         # (GIVEN)
+#         (annotator, rundata) = annotatordata
 #
-    def test_parse_batch_name(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `_parse_batch_name()` with batch name {}"
-                    .format(batchdata['name']))
-
-        # WHEN parsing batch name from workflow batch file
-        batch_items = annotator._parse_batch_name(batchdata['name'])
-
-        # THEN items should be in a dict with fields for date (string),
-        # project labels (list of strings), and flowcell ID (string)
-        assert(batch_items['date'] == batchdata['date'])
-        assert(batch_items['projects'] == batchdata['projects'])
-        assert(batch_items['flowcell_id'] == batchdata['flowcell_id'])
+#         logger.info("test `_init_flowcellrun()` with existing run")
 #
-    def test_init_workflowbatch_existing_batch(self, annotatordata,
-                                               mock_genomics_server, mock_db):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `_init_workflowbatch()` with existing batch {}"
-                    .format(batchdata['id']))
-
-        # WHEN workflow batch exists in 'workflowbatches' collection
-        mock_db.workflowbatches.insert_one(
-            {'_id': batchdata['id'],
-             'workflowbatchFile': re.sub('.*(?=genomics)', '/',
-                                         batchdata['path']),
-             'date': batchdata['date'],
-             'type': 'Galaxy workflow batch',
-             'isMock': True})
-        workflowbatch = annotator._init_workflowbatch()
-
-        # THEN existing workflow batch should be returned, and it
-        # should be mapped from the database object
-        assert(workflowbatch._id == batchdata['id'])
-        assert(hasattr(workflowbatch, 'is_mock'))
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-
-    def test_init_workflowbatch_new_batch(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `_init_workflowbatch()` with new batch {}"
-                    .format(batchdata['id']))
-
-        # WHEN workflow batch does not exist in 'workflowbatches' collection
-        workflowbatch = annotator._init_workflowbatch()
-
-        # THEN a new workflow batch should be returned
-        assert(workflowbatch._id == batchdata['id'])
-        assert(not hasattr(workflowbatch, 'is_mock'))
-
-    def test_init_workflowbatch_existing_date(self, annotatordata, mock_db):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `_init_workflowbatch()` existing prefix/date")
-
-        # WHEN workflow batch does not exist in 'workflowbatches' collection,
-        # but another batch with the same prefix and date does exist
-        mock_db.workflowbatches.insert_one(
-            {'_id': batchdata['id'],
-             'workflowbatchFile': 'someotherfile',
-             'date': batchdata['date'],
-             'type': 'Galaxy workflow batch',
-             'isMock': True})
-        workflowbatch = annotator._init_workflowbatch()
-
-        # THEN a new workflow batch should be returned with an incremented
-        # ID number
-        assert(workflowbatch._id == re.sub('\d$',
-                                           lambda x: str(int(x.group(0)) + 1),
-                                           batchdata['id']))
-        assert(not hasattr(workflowbatch, 'is_mock'))
-
-        logger.info("[rollback] remove most recently inserted "
-        "from mock database")
-        mock_db.workflowbatches.drop()
-
-    def test_update_workflowbatch(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `_update_workflowbatch()`")
-
-        # WHEN workflow batch object is updated
-        annotator._update_workflowbatch()
-
-        # THEN the object should have at least the 'workflow_id', 'date',
-        # 'projects', 'flowcell_id' attributes
-        assert(all([hasattr(annotator.workflowbatch, field)
-                    for field in ['workflow_id', 'date', 'projects',
-                                  'flowcell_id', 'date_created',
-                                  'last_updated']]))
-        assert(annotator.workflowbatch.last_updated
-               > annotator.workflowbatch.date_created)
-
-    def test_get_workflow_batch(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `get_workflow_batch()`")
-
-        # WHEN workflow batch object is returned
-        workflowbatch = annotator.get_workflow_batch()
-
-        # THEN the object should be of type GalaxyWorkflowBatch and have
-        # at least the at least the 'workflow_id', 'date',
-        # 'projects', 'flowcell_id' attributes
-        assert(type(workflowbatch) is docs.GalaxyWorkflowBatch)
-        assert(all([hasattr(workflowbatch, field)
-                    for field in ['workflow_id', 'date', 'projects',
-                                  'flowcell_id']]))
-
-    def test_get_sequenced_libraries(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `get_sequenced_libraries()`")
-
-        # WHEN collecting list of sequenced libraries for batch
-        seqlibraries = annotator.get_sequenced_libraries()
-
-        # THEN should be a list with expected number of sequenced libraries
-        assert(len(seqlibraries) == batchdata['num_samples'])
-
-    def test_get_processed_libraries(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        logger.info("test `get_processed_libraries()`")
-
-        # WHEN collecting processed libraries for current workflow batch
-        processedlibraries = annotator.get_processed_libraries()
-
-        # THEN should return expected number of processed libraries,
-        # each of which is a valid ProcessedLibrary object
-        assert(len(processedlibraries) == batchdata['num_samples'])
-        assert(all([type(pl) == docs.ProcessedLibrary
-                    for pl in processedlibraries]))
-
-    def test_check_sex(self, annotatordata, mock_db):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        # AND a processed library object
-        # TODO: not independent, fix...
-        processedlibrary = annotator.get_processed_libraries()[0]
-
-        mock_db.samples.insert({
-            '_id': processedlibrary.parent_id,
-            'reportedSex': 'female'})
-
-        # WHEN sex of processed library is verified
-        processedlibrary = annotator._check_sex(processedlibrary)
-        validationdata = processedlibrary.processed_data[0]['validation']
-
-        assert(validationdata['sex_check']['sex_check'] is not None)
-
-    def test_get_processed_libraries_w_qc(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata = annotatordata
-
-        # WHEN collecting processed libraries for current workflow batch,
-        # and QC flag is set to True
-        processedlibraries = annotator.get_processed_libraries(qc=True)
-
-        # THEN should return 2 total processed libraries, each of which
-        # is a valid ProcessedLibrary object
-        assert(len(processedlibraries) == batchdata['num_samples'])
-        assert(all([type(pl) == docs.ProcessedLibrary
-                    for pl in processedlibraries]))
-        assert('validation' in processedlibraries[0].processed_data[0])
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestProcessedLibraryAnnotator:
-    """
-    Tests methods for the `ProcessedLibraryAnnotator` class in the
-    `bripipetools.annotation.globusgalaxy` module.
-    """
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'batchnum': b, 'samplenum': s}
-                for r in range(1)
-                for b in range(2)
-                for s in range(6)
-                if not (b == 1 and s > 2)])
-    @pytest.fixture(scope='class')
-    def annotatordata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a ProcessedLibraryAnnotator with mock 'genomics' server path,
-        # and path to library folder (i.e., where data/organization is known),
-        # with specified library, project, and run ID,
-        # as well as a mock db connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        batches = rundata['submitted']['batches']
-        batchdata = batches[request.param['batchnum']]
-        samples = batchdata['samples']
-        samplename = samples[request.param['samplenum']]
-        proclib_id = ('{}_{}_processed'
-                      .format(samplename, rundata['flowcell_id']))
-
-        logger.info("[setup] ProcessedLibraryAnnotator mock instance "
-                    "for sample {}".format(samplename))
-
-        workflowbatch_id = batchdata['id']
-        # TODO: try to remove the test dependency on the io module here
-        workflowbatch_data = io.WorkflowBatchFile(
-            path=batchdata['path'],
-            state='submit').parse()
-
-        proclibannotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=workflowbatch_id,
-            params=workflowbatch_data['samples'][request.param['samplenum']],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] ProcessedLibraryAnnotator mock instance")
-        request.addfinalizer(fin)
-        return (proclibannotator, batchdata, proclib_id)
-
-    def test_init_attribute_munging(self, annotatordata):
-        # (GIVEN)
-        annotator, _, proclib_id = annotatordata
-
-        logger.info("test `__init__()` for proper attribute munging "
-                    " with sample {}".format(proclib_id))
-
-        # WHEN checking whether input arguments were automatically munged
-        # when setting annotator attributes
-
-        # THEN the processed library ID should be properly constructed as the
-        # library ID and flowcell ID, tagged as processed
-        assert(annotator.proclib_id == proclib_id)
-
-    def test_init_processedlibrary_existing_sample(self, annotatordata,
-                                                   mock_db):
-        # (GIVEN)
-        annotator, _, proclib_id = annotatordata
-
-        logger.info("test `_init_processedlibrary()` with existing sample {}"
-                    .format(proclib_id))
-
-        # WHEN processed library already exists in 'samples' collection
-        mock_db.samples.insert_one(
-            {'_id': proclib_id,
-             'type': 'processed library',
-             'isMock': True})
-        processedlibrary = annotator._init_processedlibrary()
-
-        # THEN the processed library object should be returned and
-        # should be correctly mapped from the database object
-        assert(type(processedlibrary) == docs.ProcessedLibrary)
-        assert(processedlibrary._id == proclib_id)
-        assert(hasattr(processedlibrary, 'is_mock'))
-
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.samples.drop()
-
-    def test_init_processedlibrary_new_sample(self, annotatordata):
-        # (GIVEN)
-        annotator, _, proclib_id = annotatordata
-
-        logger.info("test `_init_processedlibrary()` with new sample")
-
-        # WHEN processed library sample does not already exist in
-        # 'samples' collection
-        processedlibrary = annotator._init_processedlibrary()
-
-        # THEN a new processed library object should be returned
-        assert(type(processedlibrary) == docs.ProcessedLibrary)
-        assert(processedlibrary._id == proclib_id)
-        assert(not hasattr(processedlibrary, 'is_mock'))
-
-    def test_get_outputs(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata, proclib_id = annotatordata
-
-        logger.info("test `_get_outputs()`")
-
-        # WHEN collecting the list of outputs for a processed library
-
-        # THEN the outputs should be stored in a dict with expected length
-        assert(len(annotator._get_outputs()) == batchdata['num_outputs'])
-
-    def test_parse_output_name_onepart_source(self, annotatordata):
-        # (GIVEN)
-        annotator, _, _ = annotatordata
-
-        logger.info("test `_parse_output_name()`, one-part source")
-
-        # WHEN parsing output name from workflow batch parameter, and the
-        # source name has one parts (i.e., 'tophat')
-        output_items = annotator._parse_output_name(
-            'tophat_alignments_bam_out')
-
-        # THEN output items should be a dictionary including fields for
-        # name, type, and source
-        assert(output_items['name'] == 'tophat_alignments_bam')
-        assert(output_items['type'] == 'alignments')
-        assert(output_items['source'] == 'tophat')
-
-    def test_parse_output_name_twopart_source(self, annotatordata):
-        # (GIVEN)
-        annotator, _, _ = annotatordata
-
-        logger.info("test `_parse_output_name()`, two-part source")
-
-        # WHEN parsing output name from workflow batch parameter, and the
-        # source name has two parts (i.e., 'picard_rnaseq')
-        output_items = annotator._parse_output_name(
-            'picard_rnaseq_metrics_html_out')
-
-        # THEN output items should be a dictionary including fields for
-        # name, type, and source
-        assert(output_items['name'] == 'picard_rnaseq_metrics_html')
-        assert(output_items['type'] == 'metrics')
-        assert(output_items['source'] == 'picard_rnaseq')
-
-    def test_group_outputs(self, annotatordata, mock_genomics_server):
-        # (GIVEN)
-        annotator, _, _ = annotatordata
-
-        logger.info("test `_group_outputs()`")
-
-        # WHEN collecting the organized dictionary of outputs
-        outputs = annotator._group_outputs()
-
-        # THEN the outputs should be correctly grouped according to type
-        # and source (tool)
-        assert(set(outputs.keys())
-               == set(mock_genomics_server['out_types']))
-        assert(set([k['source'] for k in outputs['metrics']])
-               == set(['picard_align', 'tophat_stats', 'picard_markdups',
-                       'picard_rnaseq', 'htseq']))
-
-    def test_append_processed_data(self, annotatordata):
-        # (GIVEN)
-        annotator, _, _ = annotatordata
-
-        logger.info("test `_append_processed_data()`")
-
-        # WHEN batch information and outputs are added to processed data
-        # field for processed library object
-        annotator._append_processed_data()
-
-        # THEN the length of the processed data field should be 1, containing
-        # a dictionary with workflow batch ID and outputs
-        assert(len(annotator.processedlibrary.processed_data) == 1)
-        assert(set(annotator.processedlibrary.processed_data[0].keys())
-               == set(['workflowbatch_id', 'outputs']))
-        annotator.processedlibrary.processed_data = []
-
-    def test_append_processed_data_exists(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata, _ = annotatordata
-
-        logger.info("test `_append_processed_data()`")
-
-        # AND outputs for the workflow batch are already present
-        annotator.processedlibrary.processed_data.append(
-            {'workflowbatch_id': batchdata['id'],
-             'outputs': []})
-
-        # WHEN batch information and outputs are added to processed data
-        # field for processed library object
-        annotator._append_processed_data()
-
-        # THEN the length of the processed data field should be 1, containing
-        # a dictionary with workflow batch ID and outputs
-        assert(len(annotator.processedlibrary.processed_data) == 1)
-        assert(set(annotator.processedlibrary.processed_data[0].keys())
-               == set(['workflowbatch_id', 'outputs']))
-        annotator.processedlibrary.processed_data = []
-
-    def test_append_processed_data_new(self, annotatordata):
-        # (GIVEN)
-        annotator, batchdata, _ = annotatordata
-
-        logger.info("test `_append_processed_data()`")
-
-        # AND outputs from a different workflow batch are already present
-        annotator.processedlibrary.processed_data.append(
-            {'workflowbatch_id': re.sub('\d$',
-                                        lambda x: str(int(x.group(0)) + 1),
-                                        batchdata['id']),
-             'outputs': []})
-
-        # WHEN batch information and outputs are added to processed data
-        # field for processed library object
-        annotator._append_processed_data()
-
-        # THEN the length of the processed data field should be 2, containing
-        # a dictionary with workflow batch ID and outputs
-        assert(len(annotator.processedlibrary.processed_data) == 2)
-        assert(set(annotator.processedlibrary.processed_data[1].keys())
-               == set(['workflowbatch_id', 'outputs']))
-        annotator.processedlibrary.processed_data = []
-
-    def test_update_processedlibrary(self, annotatordata):
-        # (GIVEN)
-        annotator, _, _ = annotatordata
-
-        logger.info("test `_update_processedlibrary()`")
-
-        # WHEN processed library object is updated
-        annotator._update_processedlibrary()
-
-        # THEN the object should have at least the 'parent_id' and
-        # 'processed_data', and 'processed_data' should be length 1
-        assert(all([hasattr(annotator.processedlibrary, field)
-                    for field in ['parent_id', 'processed_data',
-                                  'date_created', 'last_updated']]))
-        assert(len(annotator.processedlibrary.processed_data) == 1)
-        assert(annotator.processedlibrary.last_updated
-               > annotator.processedlibrary.date_created)
+#         # WHEN flowcell run already exists in 'runs' collection
+#         mock_db.runs.insert_one(
+#             {'_id': rundata['run_id'],
+#              'type': 'flowcell',
+#              'isMock': True})
+#         flowcellrun = annotator._init_flowcellrun()
+#
+#         # THEN the flowcell run object should be returned and
+#         # should be correctly mapped from the database object
+#         assert(type(flowcellrun) == docs.FlowcellRun)
+#         assert(flowcellrun._id == rundata['run_id'])
+#         assert(hasattr(flowcellrun, 'is_mock'))
+#
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.runs.drop()
+#
+#     def test_init_flowcellrun_new_run(self, annotatordata):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         logger.info("test `_init_flowcellrun()` with new run")
+#
+#         # WHEN flowcell run run does not already exist in
+#         # 'runs' collection
+#         flowcellrun = annotator._init_flowcellrun()
+#
+#         # THEN a new flowcell run object should be returned
+#         assert(type(flowcellrun) == docs.FlowcellRun)
+#         assert(flowcellrun._id == rundata['run_id'])
+#         assert(not hasattr(flowcellrun, 'is_mock'))
+# #
+#     def test_get_flowcell_path(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         logger.info("test `_get_flowcell_path()`")
+#
+#         # WHEN searching for flowcell run ID in 'genomics' path
+#
+#         # THEN correct flowcell folder should be found in 'genomics/Illumina/'
+#         assert(annotator._get_flowcell_path() == rundata['path'])
+#
+#     def test_get_unaligned_path(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         logger.info("test `_get_unaligned_path()`")
+#
+#         # WHEN searching for 'Unaligned' folder
+#
+#         # THEN path returned should be 'genomics/Illumina/<run_id>/Unaligned'
+#         assert(annotator._get_unaligned_path() == rundata['unaligned']['path'])
+#
+#     def test_get_projects(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         logger.info("test `_get_projects()`")
+#
+#         # WHEN listing unaligned projects
+#         projects = annotator.get_projects()
+#
+#         # THEN should find expected number of projects
+#         assert(len(projects) == len(rundata['unaligned']['projects']))
+#
+#     @pytest.mark.parametrize("projectnum", [0, 1, 2])
+#     def test_get_libraries_single_project(self, annotatordata,
+#                                           mock_genomics_server, projectnum):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         # AND unaligned samples for a single project
+#         projectdata = rundata['unaligned']['projects'][projectnum]
+#
+#         logger.info("test `_get_libraries()`, single project ({})"
+#                     .format(projectdata['name']))
+#
+#         # WHEN listing libraries for the project
+#         libraries = annotator.get_libraries(projectdata['name'])
+#
+#         # THEN should find the expected number of libaries (samples)
+#         assert(len(libraries) == len(projectdata['samples']))
+#
+#     def test_get_libraries_all_projects(self, annotatordata,
+#                                         mock_genomics_server):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         # AND list of unaligned projects
+#         projects = rundata['unaligned']['projects']
+#
+#         logger.info("test `_get_libraries()`, all projects")
+#
+#         # WHEN listing libraries for all projects
+#         libraries = annotator.get_libraries()
+#
+#         # THEN should find expected number of libraries
+#         assert(len(libraries)
+#                 == sum(map(lambda x: len(x['samples']), projects)))
+#
+#     @pytest.mark.parametrize("projectnum", [0, 1, 2])
+#     def test_get_sequenced_libraries_single_project(self, annotatordata,
+#                                                     mock_genomics_server,
+#                                                     projectnum):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         # AND unaligned samples for a single project
+#         projectdata = rundata['unaligned']['projects'][projectnum]
+#
+#         logger.info("test `get_sequenced_libraries()`, single project ({})"
+#                     .format(projectdata['name']))
+#
+#         # WHEN collecting sequenced libraries for project
+#         sequencedlibraries = annotator.get_sequenced_libraries(
+#             projectdata['name'])
+#
+#         # THEN should find excpeted number of sequenced libraries
+#         assert(len(sequencedlibraries) == len(projectdata['samples']))
+#
+#     def test_get_sequenced_libraries_all_projects(self, annotatordata,
+#                                                   mock_genomics_server):
+#         # (GIVEN)
+#         annotator, rundata = annotatordata
+#
+#         # AND list of unaligned projects
+#         projects = rundata['unaligned']['projects']
+#
+#         logger.info("test `get_sequenced_libraries()`, all projects")
+#
+#         # WHEN collecting sequenced libraries for all projects
+#         sequencedlibraries = annotator.get_sequenced_libraries()
+#
+#         # THEN should find 31 total libraries
+#         assert(len(sequencedlibraries)
+#                == sum(map(lambda x: len(x['samples']), projects)))
+#
+#
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestSequencedLibraryAnnotator:
+#     """
+#     Tests methods for the `SequencedLibraryAnnotator` class in the
+#     `bripipetools.annotation.illuminaseq` module.
+#     """
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'projectnum': p, 'samplenum': s}
+#                 for r in range(1)
+#                 for p in range(3)
+#                 for s in range(3)])
+#     def annotatordata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a SequencedLibraryAnnotator with mock 'genomics' server path,
+#         # and path to library folder (i.e., where data/organization is known),
+#         # with specified library, project, and run ID, as well as a mock
+#         # db connection
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         projects = rundata['unaligned']['projects']
+#         projectdata = projects[request.param['projectnum']]
+#         samples = projectdata['samples']
+#         sampledata = samples[request.param['samplenum']]
+#
+#         logger.info("[setup] SequencedLibraryAnnotator mock instance "
+#                     " for sample {} in project {} from run {}"
+#                     .format(sampledata['name'], projectdata['name'],
+#                             rundata['flowcell_id']))
+#
+#         seqlibannotator = annotation.SequencedLibraryAnnotator(
+#             path=sampledata['path'],
+#             library=os.path.basename(sampledata['path']),
+#             project=os.path.basename(projectdata['path']),
+#             run_id=rundata['run_id'],
+#             db=mock_db)
+#
+#         def fin():
+#             logger.info("[teardown] SequencedLibraryAnnotator mock instance")
+#         request.addfinalizer(fin)
+#         return (seqlibannotator, rundata, sampledata)
+#
+#     def test_init_attribute_munging(self, annotatordata):
+#         # (GIVEN)
+#         annotator, rundata, sampledata = annotatordata
+#         seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
+#
+#         logger.info("test `__init__()` for proper attribute munging")
+#
+#         # WHEN checking whether input arguments were automatically munged
+#         # when setting annotator attributes
+#
+#         # THEN the sequenced library ID should be properly constructed as the
+#         # library ID and flowcell ID
+#         assert(annotator.seqlib_id == seqlib_id)
+#
+#     def test_init_sequencedlibrary_existing_sample(self, annotatordata,
+#                                                    mock_db):
+#         # (GIVEN)
+#         annotator, rundata, sampledata = annotatordata
+#         seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
+#
+#         logger.info("test `_init_sequencedlibrary()` with existing sample {}"
+#                     .format(seqlib_id))
+#
+#         # WHEN sequenced library already exists in 'samples' collection
+#         mock_db.samples.insert_one(
+#             {'_id': seqlib_id,
+#              'type': 'sequenced library',
+#              'isMock': True})
+#         sequencedlibrary = annotator._init_sequencedlibrary()
+#
+#         # THEN the sequenced library object should be returned and
+#         # should be correctly mapped from the database object
+#         assert(type(sequencedlibrary) == docs.SequencedLibrary)
+#         assert(sequencedlibrary._id == seqlib_id)
+#         assert(hasattr(sequencedlibrary, 'is_mock'))
+#
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.samples.drop()
+#
+#     def test_init_sequencedlibrary_new_sample(self, annotatordata):
+#         # (GIVEN)
+#         annotator, rundata, sampledata = annotatordata
+#         seqlib_id = '{}_{}'.format(sampledata['name'], rundata['flowcell_id'])
+#
+#         logger.info("test `_init_sequencedlibrary()` with new sample {}"
+#                     .format(seqlib_id))
+#
+#         # WHEN sequenced library sample does not already exist in
+#         # 'samples' collection
+#         sequencedlibrary = annotator._init_sequencedlibrary()
+#
+#         # THEN a new sequenced library object should be returned
+#         assert(type(sequencedlibrary) == docs.SequencedLibrary)
+#         assert(sequencedlibrary._id == seqlib_id)
+#         assert(not hasattr(sequencedlibrary, 'is_mock'))
+#
+#     def test_get_raw_data(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, _, sampledata = annotatordata
+#
+#         logger.info("test `_get_raw_data()` for sample {}"
+#                     .format(sampledata['name']))
+#
+#         # WHEN collecting raw data for a sequenced library
+#         raw_data = annotator._get_raw_data()
+#
+#         # THEN should be a list of dicts, with the correct details for each
+#         # FASTQ file identified
+#         assert(set(f['path'] for f in raw_data)
+#                 == set(f for f in os.listdir(sampledata['path'])
+#                        if not re.search('empty', f)))
+#
+#     def test_update_sequencedlibrary(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, sampledata = annotatordata
+#
+#         logger.info("test `_update_sequencedlibrary()` for sample {}"
+#                     .format(sampledata['name']))
+#
+#         # WHEN sequenced library object is updated
+#         annotator._update_sequencedlibrary()
+#
+#         # THEN the object should have at least the 'run_id', 'project_id',
+#         # 'subproject_id', 'parent_id' and 'raw_data' attributes
+#         assert(all([hasattr(annotator.sequencedlibrary, field)
+#                     for field in ['run_id', 'project_id', 'subproject_id',
+#                                   'parent_id', 'raw_data', 'date_created',
+#                                   'last_updated']]))
+#         assert(annotator.sequencedlibrary.last_updated
+#                > annotator.sequencedlibrary.date_created)
+#
+#     def test_get_sequenced_library(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, sampledata = annotatordata
+#
+#         logger.info("test `get_sequenced_library()` for sample {}"
+#                     .format(sampledata['name']))
+#
+#         # WHEN sequenced library object is returned
+#         sequencedlibrary = annotator.get_sequenced_library()
+#
+#         # THEN the object should be of type SequencedLibrary and have
+#         # at least the 'run_id', 'project_id', 'subproject_id', 'parent_id',
+#         # and 'raw_data' attributes
+#         assert(type(sequencedlibrary) is docs.SequencedLibrary)
+#         assert(all([hasattr(sequencedlibrary, field)
+#                     for field in ['run_id', 'project_id', 'subproject_id',
+#                                   'parent_id', 'raw_data']]))
+#
+#
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestWorkflowBatchAnnotator:
+#     """
+#     Tests methods for the `WorkflowBatchAnnotator` class in the
+#     `bripipetools.annotation.globusgalaxy` module.
+#     """
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'batchnum': b}
+#                 for r in range(1)
+#                 for b in range(2)])
+#     @pytest.fixture(scope='class')
+#     def annotatordata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a WorkflowBatchAnnotator with mock 'genomics' server path,
+#         # and path to workflow batch file with specified genomics root,
+#         # as well as a mock db connection
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         batches = rundata['submitted']['batches']
+#         batchdata = batches[request.param['batchnum']]
+#
+#         logger.info("[setup] WorkflowBatchAnnotator mock instance "
+#                     "for batch {}".format(os.path.basename(batchdata['path'])))
+#
+#         wflowbatchannotator = annotation.WorkflowBatchAnnotator(
+#             workflowbatch_file=batchdata['path'],
+#             db=mock_db,
+#             genomics_root=mock_genomics_server['root']['path'])
+#
+#         def fin():
+#             logger.info("[teardown] WorkflowBatchAnnotator mock instance")
+#         request.addfinalizer(fin)
+#         return (wflowbatchannotator, batchdata)
+#
+#     def test_init_file_parsing(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `__init__()` for proper file parsing "
+#                     "with batch {}"
+#                     .format(os.path.basename(batchdata['path'])))
+#
+#         # WHEN checking whether input arguments were automatically munged
+#         # when setting annotator attributes
+#         workflowbatch_data = annotator.workflowbatch_data
+#
+#         # THEN the workflow batch data should be a dictionary with fields for
+#         # workflow name, parameters, and samples
+#         assert(workflowbatch_data['workflow_name'] == batchdata['workflow'])
+#         assert(len(workflowbatch_data['parameters']) == batchdata['num_params'])
+#         assert(len(workflowbatch_data['samples']) == batchdata['num_samples'])
+# #
+#     def test_parse_batch_name(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `_parse_batch_name()` with batch name {}"
+#                     .format(batchdata['name']))
+#
+#         # WHEN parsing batch name from workflow batch file
+#         batch_items = annotator._parse_batch_name(batchdata['name'])
+#
+#         # THEN items should be in a dict with fields for date (string),
+#         # project labels (list of strings), and flowcell ID (string)
+#         assert(batch_items['date'] == batchdata['date'])
+#         assert(batch_items['projects'] == batchdata['projects'])
+#         assert(batch_items['flowcell_id'] == batchdata['flowcell_id'])
+# #
+#     def test_init_workflowbatch_existing_batch(self, annotatordata,
+#                                                mock_genomics_server, mock_db):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `_init_workflowbatch()` with existing batch {}"
+#                     .format(batchdata['id']))
+#
+#         # WHEN workflow batch exists in 'workflowbatches' collection
+#         mock_db.workflowbatches.insert_one(
+#             {'_id': batchdata['id'],
+#              'workflowbatchFile': re.sub('.*(?=genomics)', '/',
+#                                          batchdata['path']),
+#              'date': batchdata['date'],
+#              'type': 'Galaxy workflow batch',
+#              'isMock': True})
+#         workflowbatch = annotator._init_workflowbatch()
+#
+#         # THEN existing workflow batch should be returned, and it
+#         # should be mapped from the database object
+#         assert(workflowbatch._id == batchdata['id'])
+#         assert(hasattr(workflowbatch, 'is_mock'))
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#
+#     def test_init_workflowbatch_new_batch(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `_init_workflowbatch()` with new batch {}"
+#                     .format(batchdata['id']))
+#
+#         # WHEN workflow batch does not exist in 'workflowbatches' collection
+#         workflowbatch = annotator._init_workflowbatch()
+#
+#         # THEN a new workflow batch should be returned
+#         assert(workflowbatch._id == batchdata['id'])
+#         assert(not hasattr(workflowbatch, 'is_mock'))
+#
+#     def test_init_workflowbatch_existing_date(self, annotatordata, mock_db):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `_init_workflowbatch()` existing prefix/date")
+#
+#         # WHEN workflow batch does not exist in 'workflowbatches' collection,
+#         # but another batch with the same prefix and date does exist
+#         mock_db.workflowbatches.insert_one(
+#             {'_id': batchdata['id'],
+#              'workflowbatchFile': 'someotherfile',
+#              'date': batchdata['date'],
+#              'type': 'Galaxy workflow batch',
+#              'isMock': True})
+#         workflowbatch = annotator._init_workflowbatch()
+#
+#         # THEN a new workflow batch should be returned with an incremented
+#         # ID number
+#         assert(workflowbatch._id == re.sub('\d$',
+#                                            lambda x: str(int(x.group(0)) + 1),
+#                                            batchdata['id']))
+#         assert(not hasattr(workflowbatch, 'is_mock'))
+#
+#         logger.info("[rollback] remove most recently inserted "
+#         "from mock database")
+#         mock_db.workflowbatches.drop()
+#
+#     def test_update_workflowbatch(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `_update_workflowbatch()`")
+#
+#         # WHEN workflow batch object is updated
+#         annotator._update_workflowbatch()
+#
+#         # THEN the object should have at least the 'workflow_id', 'date',
+#         # 'projects', 'flowcell_id' attributes
+#         assert(all([hasattr(annotator.workflowbatch, field)
+#                     for field in ['workflow_id', 'date', 'projects',
+#                                   'flowcell_id', 'date_created',
+#                                   'last_updated']]))
+#         assert(annotator.workflowbatch.last_updated
+#                > annotator.workflowbatch.date_created)
+#
+#     def test_get_workflow_batch(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `get_workflow_batch()`")
+#
+#         # WHEN workflow batch object is returned
+#         workflowbatch = annotator.get_workflow_batch()
+#
+#         # THEN the object should be of type GalaxyWorkflowBatch and have
+#         # at least the at least the 'workflow_id', 'date',
+#         # 'projects', 'flowcell_id' attributes
+#         assert(type(workflowbatch) is docs.GalaxyWorkflowBatch)
+#         assert(all([hasattr(workflowbatch, field)
+#                     for field in ['workflow_id', 'date', 'projects',
+#                                   'flowcell_id']]))
+#
+#     def test_get_sequenced_libraries(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `get_sequenced_libraries()`")
+#
+#         # WHEN collecting list of sequenced libraries for batch
+#         seqlibraries = annotator.get_sequenced_libraries()
+#
+#         # THEN should be a list with expected number of sequenced libraries
+#         assert(len(seqlibraries) == batchdata['num_samples'])
+#
+#     def test_get_processed_libraries(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         logger.info("test `get_processed_libraries()`")
+#
+#         # WHEN collecting processed libraries for current workflow batch
+#         processedlibraries = annotator.get_processed_libraries()
+#
+#         # THEN should return expected number of processed libraries,
+#         # each of which is a valid ProcessedLibrary object
+#         assert(len(processedlibraries) == batchdata['num_samples'])
+#         assert(all([type(pl) == docs.ProcessedLibrary
+#                     for pl in processedlibraries]))
+#
+#     def test_check_sex(self, annotatordata, mock_db):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         # AND a processed library object
+#         # TODO: not independent, fix...
+#         processedlibrary = annotator.get_processed_libraries()[0]
+#
+#         mock_db.samples.insert({
+#             '_id': processedlibrary.parent_id,
+#             'reportedSex': 'female'})
+#
+#         # WHEN sex of processed library is verified
+#         processedlibrary = annotator._check_sex(processedlibrary)
+#         validationdata = processedlibrary.processed_data[0]['validation']
+#
+#         assert(validationdata['sex_check']['sex_check'] is not None)
+#
+#     def test_get_processed_libraries_w_qc(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata = annotatordata
+#
+#         # WHEN collecting processed libraries for current workflow batch,
+#         # and QC flag is set to True
+#         processedlibraries = annotator.get_processed_libraries(qc=True)
+#
+#         # THEN should return 2 total processed libraries, each of which
+#         # is a valid ProcessedLibrary object
+#         assert(len(processedlibraries) == batchdata['num_samples'])
+#         assert(all([type(pl) == docs.ProcessedLibrary
+#                     for pl in processedlibraries]))
+#         assert('validation' in processedlibraries[0].processed_data[0])
+#
+#
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestProcessedLibraryAnnotator:
+#     """
+#     Tests methods for the `ProcessedLibraryAnnotator` class in the
+#     `bripipetools.annotation.globusgalaxy` module.
+#     """
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'batchnum': b, 'samplenum': s}
+#                 for r in range(1)
+#                 for b in range(2)
+#                 for s in range(6)
+#                 if not (b == 1 and s > 2)])
+#     @pytest.fixture(scope='class')
+#     def annotatordata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a ProcessedLibraryAnnotator with mock 'genomics' server path,
+#         # and path to library folder (i.e., where data/organization is known),
+#         # with specified library, project, and run ID,
+#         # as well as a mock db connection
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         batches = rundata['submitted']['batches']
+#         batchdata = batches[request.param['batchnum']]
+#         samples = batchdata['samples']
+#         samplename = samples[request.param['samplenum']]
+#         proclib_id = ('{}_{}_processed'
+#                       .format(samplename, rundata['flowcell_id']))
+#
+#         logger.info("[setup] ProcessedLibraryAnnotator mock instance "
+#                     "for sample {}".format(samplename))
+#
+#         workflowbatch_id = batchdata['id']
+#         # TODO: try to remove the test dependency on the io module here
+#         workflowbatch_data = io.WorkflowBatchFile(
+#             path=batchdata['path'],
+#             state='submit').parse()
+#
+#         proclibannotator = annotation.ProcessedLibraryAnnotator(
+#             workflowbatch_id=workflowbatch_id,
+#             params=workflowbatch_data['samples'][request.param['samplenum']],
+#             db=mock_db)
+#
+#         def fin():
+#             logger.info("[teardown] ProcessedLibraryAnnotator mock instance")
+#         request.addfinalizer(fin)
+#         return (proclibannotator, batchdata, proclib_id)
+#
+#     def test_init_attribute_munging(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, proclib_id = annotatordata
+#
+#         logger.info("test `__init__()` for proper attribute munging "
+#                     " with sample {}".format(proclib_id))
+#
+#         # WHEN checking whether input arguments were automatically munged
+#         # when setting annotator attributes
+#
+#         # THEN the processed library ID should be properly constructed as the
+#         # library ID and flowcell ID, tagged as processed
+#         assert(annotator.proclib_id == proclib_id)
+#
+#     def test_init_processedlibrary_existing_sample(self, annotatordata,
+#                                                    mock_db):
+#         # (GIVEN)
+#         annotator, _, proclib_id = annotatordata
+#
+#         logger.info("test `_init_processedlibrary()` with existing sample {}"
+#                     .format(proclib_id))
+#
+#         # WHEN processed library already exists in 'samples' collection
+#         mock_db.samples.insert_one(
+#             {'_id': proclib_id,
+#              'type': 'processed library',
+#              'isMock': True})
+#         processedlibrary = annotator._init_processedlibrary()
+#
+#         # THEN the processed library object should be returned and
+#         # should be correctly mapped from the database object
+#         assert(type(processedlibrary) == docs.ProcessedLibrary)
+#         assert(processedlibrary._id == proclib_id)
+#         assert(hasattr(processedlibrary, 'is_mock'))
+#
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.samples.drop()
+#
+#     def test_init_processedlibrary_new_sample(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, proclib_id = annotatordata
+#
+#         logger.info("test `_init_processedlibrary()` with new sample")
+#
+#         # WHEN processed library sample does not already exist in
+#         # 'samples' collection
+#         processedlibrary = annotator._init_processedlibrary()
+#
+#         # THEN a new processed library object should be returned
+#         assert(type(processedlibrary) == docs.ProcessedLibrary)
+#         assert(processedlibrary._id == proclib_id)
+#         assert(not hasattr(processedlibrary, 'is_mock'))
+#
+#     def test_get_outputs(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata, proclib_id = annotatordata
+#
+#         logger.info("test `_get_outputs()`")
+#
+#         # WHEN collecting the list of outputs for a processed library
+#
+#         # THEN the outputs should be stored in a dict with expected length
+#         assert(len(annotator._get_outputs()) == batchdata['num_outputs'])
+#
+#     def test_parse_output_name_onepart_source(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_parse_output_name()`, one-part source")
+#
+#         # WHEN parsing output name from workflow batch parameter, and the
+#         # source name has one parts (i.e., 'tophat')
+#         output_items = annotator._parse_output_name(
+#             'tophat_alignments_bam_out')
+#
+#         # THEN output items should be a dictionary including fields for
+#         # name, type, and source
+#         assert(output_items['name'] == 'tophat_alignments_bam')
+#         assert(output_items['type'] == 'alignments')
+#         assert(output_items['source'] == 'tophat')
+#
+#     def test_parse_output_name_twopart_source(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_parse_output_name()`, two-part source")
+#
+#         # WHEN parsing output name from workflow batch parameter, and the
+#         # source name has two parts (i.e., 'picard_rnaseq')
+#         output_items = annotator._parse_output_name(
+#             'picard_rnaseq_metrics_html_out')
+#
+#         # THEN output items should be a dictionary including fields for
+#         # name, type, and source
+#         assert(output_items['name'] == 'picard_rnaseq_metrics_html')
+#         assert(output_items['type'] == 'metrics')
+#         assert(output_items['source'] == 'picard_rnaseq')
+#
+#     def test_group_outputs(self, annotatordata, mock_genomics_server):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_group_outputs()`")
+#
+#         # WHEN collecting the organized dictionary of outputs
+#         outputs = annotator._group_outputs()
+#
+#         # THEN the outputs should be correctly grouped according to type
+#         # and source (tool)
+#         assert(set(outputs.keys())
+#                == set(mock_genomics_server['out_types']))
+#         assert(set([k['source'] for k in outputs['metrics']])
+#                == set(['picard_align', 'tophat_stats', 'picard_markdups',
+#                        'picard_rnaseq', 'htseq']))
+#
+#     def test_append_processed_data(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_append_processed_data()`")
+#
+#         # WHEN batch information and outputs are added to processed data
+#         # field for processed library object
+#         annotator._append_processed_data()
+#
+#         # THEN the length of the processed data field should be 1, containing
+#         # a dictionary with workflow batch ID and outputs
+#         assert(len(annotator.processedlibrary.processed_data) == 1)
+#         assert(set(annotator.processedlibrary.processed_data[0].keys())
+#                == set(['workflowbatch_id', 'outputs']))
+#         annotator.processedlibrary.processed_data = []
+#
+#     def test_append_processed_data_exists(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata, _ = annotatordata
+#
+#         logger.info("test `_append_processed_data()`")
+#
+#         # AND outputs for the workflow batch are already present
+#         annotator.processedlibrary.processed_data.append(
+#             {'workflowbatch_id': batchdata['id'],
+#              'outputs': []})
+#
+#         # WHEN batch information and outputs are added to processed data
+#         # field for processed library object
+#         annotator._append_processed_data()
+#
+#         # THEN the length of the processed data field should be 1, containing
+#         # a dictionary with workflow batch ID and outputs
+#         assert(len(annotator.processedlibrary.processed_data) == 1)
+#         assert(set(annotator.processedlibrary.processed_data[0].keys())
+#                == set(['workflowbatch_id', 'outputs']))
+#         annotator.processedlibrary.processed_data = []
+#
+#     def test_append_processed_data_new(self, annotatordata):
+#         # (GIVEN)
+#         annotator, batchdata, _ = annotatordata
+#
+#         logger.info("test `_append_processed_data()`")
+#
+#         # AND outputs from a different workflow batch are already present
+#         annotator.processedlibrary.processed_data.append(
+#             {'workflowbatch_id': re.sub('\d$',
+#                                         lambda x: str(int(x.group(0)) + 1),
+#                                         batchdata['id']),
+#              'outputs': []})
+#
+#         # WHEN batch information and outputs are added to processed data
+#         # field for processed library object
+#         annotator._append_processed_data()
+#
+#         # THEN the length of the processed data field should be 2, containing
+#         # a dictionary with workflow batch ID and outputs
+#         assert(len(annotator.processedlibrary.processed_data) == 2)
+#         assert(set(annotator.processedlibrary.processed_data[1].keys())
+#                == set(['workflowbatch_id', 'outputs']))
+#         annotator.processedlibrary.processed_data = []
+#
+#     def test_update_processedlibrary(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_update_processedlibrary()`")
+#
+#         # WHEN processed library object is updated
+#         annotator._update_processedlibrary()
+#
+#         # THEN the object should have at least the 'parent_id' and
+#         # 'processed_data', and 'processed_data' should be length 1
+#         assert(all([hasattr(annotator.processedlibrary, field)
+#                     for field in ['parent_id', 'processed_data',
+#                                   'date_created', 'last_updated']]))
+#         assert(len(annotator.processedlibrary.processed_data) == 1)
+#         assert(annotator.processedlibrary.last_updated
+#                > annotator.processedlibrary.date_created)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -14,13 +14,13 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope='function')
 def mock_db():
-    # GIVEN a mocked version of the TG3 Mongo database
-    logger.info(("[setup] mock database, connect "
-                 "to mock Mongo database"))
+    # GIVEN a mock_ed version of the TG3 Mongo database
+    logger.info(("[setup] mock_ database, connect "
+                 "to mock_ Mongo database"))
 
     yield mongomock.MongoClient().db
-    logger.debug(("[teardown] mock database, disconnect "
-                  "from mock Mongo database"))
+    logger.debug(("[teardown] mock_ database, disconnect "
+                  "from mock_ Mongo database"))
 
 
 class TestSequencedLibraryAnnotator:
@@ -31,122 +31,122 @@ class TestSequencedLibraryAnnotator:
     def test_init_sequencedlibrary_for_existing_sample(self, mock_db):
         # GIVEN a sequenced library ID and a connection to a database in which
         # a document corresponding to the sequenced library exists already
-        mockid = 'lib1111_C00000XX'
+        mock_id = 'lib1111_C00000XX'
 
         mock_db.samples.insert_one(
-            {'_id': mockid,
+            {'_id': mock_id,
              'type': 'sequenced library'}
         )
 
         # AND an annotator object is created for the sequenced library with
         # project and library folder names, run ID, and an arbitrary path to
         # the libraries raw data
-        mocklib = 'lib1111-1111'
-        mockproject = 'P1-1-1111'
-        mockrunid = '161231_INSTID_0001_AC00000XX'
+        mock_lib = 'lib1111-1111'
+        mock_project = 'P1-1-1111'
+        mock_runid = '161231_INSTID_0001_AC00000XX'
         annotator = annotation.SequencedLibraryAnnotator(
             path='mock-path-to-raw-data.fastq.gz',
-            library=mocklib,
-            project=mockproject,
-            run_id=mockrunid,
+            library=mock_lib,
+            project=mock_project,
+            run_id=mock_runid,
             db=mock_db
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_sequencedlibrary()
+        test_object = annotator._init_sequencedlibrary()
 
         # THEN the sequenced library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.SequencedLibrary)
-        assert (testobject._id == mockid)
-        assert testobject.is_mapped
+        assert (type(test_object) == docs.SequencedLibrary)
+        assert (test_object._id == mock_id)
+        assert test_object.is_mapped
 
     def test_init_sequencedlibrary_for_existing_sample(self, mock_db):
         # GIVEN a sequenced library ID and a connection to a database in which
         # a document corresponding to the sequenced library does not exist
-        mockid = 'lib1111_C00000XX'
+        mock_id = 'lib1111_C00000XX'
 
         # AND an annotator object is created for the sequenced library with
         # project and library folder names, run ID, and an arbitrary path to
         # the libraries raw data
-        mocklib = 'lib1111-1111'
-        mockproject = 'P1-1-1111'
-        mockrunid = '161231_INSTID_0001_AC00000XX'
+        mock_lib = 'lib1111-1111'
+        mock_project = 'P1-1-1111'
+        mock_runid = '161231_INSTID_0001_AC00000XX'
         annotator = annotation.SequencedLibraryAnnotator(
             path='mock-path-to-raw-data.fastq.gz',
-            library=mocklib,
-            project=mockproject,
-            run_id=mockrunid,
+            library=mock_lib,
+            project=mock_project,
+            run_id=mock_runid,
             db=mock_db
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_sequencedlibrary()
+        test_object = annotator._init_sequencedlibrary()
 
         # THEN the sequenced library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.SequencedLibrary)
-        assert (testobject._id == mockid)
-        assert not testobject.is_mapped
+        assert (type(test_object) == docs.SequencedLibrary)
+        assert (test_object._id == mock_id)
+        assert not test_object.is_mapped
 
     def test_get_raw_data(self, mock_db, tmpdir):
         # GIVEN an annotator object created for the sequenced library with
         # project and library folder names, run ID, and the full path to the
         # folder containing raw data (i.e., one or more FASTQ files)
-        mocklib = 'lib1111'
-        mockproject = 'P1-1'
-        mockrunid = '161231_INSTID_0001_AC00000XX'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrunid)
+        mock_lib = 'lib1111'
+        mock_project = 'P1-1'
+        mock_runid = '161231_INSTID_0001_AC00000XX'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_runid)
                     .mkdir('Unaligned')
-                    .mkdir(mockproject)
-                    .mkdir(mocklib))
-        mockdata = 'sample-name_S001_L001_R1_001.fastq.gz'
-        mockpath.ensure(mockdata)
+                    .mkdir(mock_project)
+                    .mkdir(mock_lib))
+        mock_data = 'sample-name_S001_L001_R1_001.fastq.gz'
+        mock_path.ensure(mock_data)
         annotator = annotation.SequencedLibraryAnnotator(
-            path=str(mockpath),
-            library=mocklib,
-            project=mockproject,
-            run_id=mockrunid,
+            path=str(mock_path),
+            library=mock_lib,
+            project=mock_project,
+            run_id=mock_runid,
             db=mock_db
         )
 
         # WHEN raw data details are recovered for the library
-        testdata = annotator._get_raw_data()
+        test_data = annotator._get_raw_data()
 
         # THEN the path field of the raw data file should match
         # the expected result
-        assert (testdata[0]['path'] == mockdata)
+        assert (test_data[0]['path'] == mock_data)
 
     def test_update_sequencedlibrary(self, mock_db, tmpdir):
         # GIVEN an annotator object created for a sequenced library with
         # project and library folder names, run ID, and the full path to the
         # folder containing raw data (i.e., one or more FASTQ files)
-        mocklib = 'lib1111'
-        mockproject = 'P1-1'
-        mockrunid = '161231_INSTID_0001_AC00000XX'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrunid)
+        mock_lib = 'lib1111'
+        mock_project = 'P1-1'
+        mock_runid = '161231_INSTID_0001_AC00000XX'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_runid)
                     .mkdir('Unaligned')
-                    .mkdir(mockproject)
-                    .mkdir(mocklib))
-        mockdata = 'sample-name_S001_L001_R1_001.fastq.gz'
-        mockpath.ensure(mockdata)
+                    .mkdir(mock_project)
+                    .mkdir(mock_lib))
+        mock_data = 'sample-name_S001_L001_R1_001.fastq.gz'
+        mock_path.ensure(mock_data)
         annotator = annotation.SequencedLibraryAnnotator(
-            path=str(mockpath),
-            library=mocklib,
-            project=mockproject,
-            run_id=mockrunid,
+            path=str(mock_path),
+            library=mock_lib,
+            project=mock_project,
+            run_id=mock_runid,
             db=mock_db
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding sequenced library ID
-        mockid = 'lib1111_C00000XX'
-        mockobject = mock.create_autospec(docs.SequencedLibrary)
-        mockobject._id = mockid
-        mockobject.is_mapped = True
-        annotator.sequencedlibrary = mockobject
+        mock_id = 'lib1111_C00000XX'
+        mock_object = mock.create_autospec(docs.SequencedLibrary)
+        mock_object._id = mock_id
+        mock_object.is_mapped = True
+        annotator.sequencedlibrary = mock_object
 
         # WHEN the mapped model object is updated to add any missing fields
         annotator._update_sequencedlibrary()
@@ -160,39 +160,39 @@ class TestSequencedLibraryAnnotator:
         # GIVEN an annotator object created for a sequenced library with
         # project and library folder names, run ID, and the full path to the
         # folder containing raw data (i.e., one or more FASTQ files)
-        mocklib = 'lib1111'
-        mockproject = 'P1-1'
-        mockrunid = '161231_INSTID_0001_AC00000XX'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrunid)
+        mock_lib = 'lib1111'
+        mock_project = 'P1-1'
+        mock_runid = '161231_INSTID_0001_AC00000XX'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_runid)
                     .mkdir('Unaligned')
-                    .mkdir(mockproject)
-                    .mkdir(mocklib))
-        mockdata = 'sample-name_S001_L001_R1_001.fastq.gz'
-        mockpath.ensure(mockdata)
+                    .mkdir(mock_project)
+                    .mkdir(mock_lib))
+        mock_data = 'sample-name_S001_L001_R1_001.fastq.gz'
+        mock_path.ensure(mock_data)
         annotator = annotation.SequencedLibraryAnnotator(
-            path=str(mockpath),
-            library=mocklib,
-            project=mockproject,
-            run_id=mockrunid,
+            path=str(mock_path),
+            library=mock_lib,
+            project=mock_project,
+            run_id=mock_runid,
             db=mock_db
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding sequenced library ID
-        mockid = 'lib1111_C00000XX'
-        mockobject = mock.create_autospec(docs.SequencedLibrary)
-        mockobject._id = mockid
-        mockobject.is_mapped = True
-        annotator.sequencedlibrary = mockobject
+        mock_id = 'lib1111_C00000XX'
+        mock_object = mock.create_autospec(docs.SequencedLibrary)
+        mock_object._id = mock_id
+        mock_object.is_mapped = True
+        annotator.sequencedlibrary = mock_object
 
         # WHEN the mapped model object is retrieved
-        testobject = annotator.get_sequenced_library()
+        test_object = annotator.get_sequenced_library()
 
         # THEN the model object should now have expected fields including
         # for raw data, and should no longer be flagged as mapped
-        assert (hasattr(testobject, 'raw_data'))
-        assert not testobject.is_mapped
+        assert (hasattr(test_object, 'raw_data'))
+        assert not test_object.is_mapped
 
 
 class TestFlowcellRunAnnotator:
@@ -203,94 +203,94 @@ class TestFlowcellRunAnnotator:
     def test_init_flowcellrun_for_existing_run(self, mock_db):
         # GIVEN a flowcell run ID and a connection to a database in which
         # a document corresponding to the flowcell run exists already
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
         mock_db.runs.insert_one(
-            {'_id': mockid,
+            {'_id': mock_id,
              'type': 'flowcell'}
         )
 
         # AND an annotator object is created for the flowcell run with
         # an arbitrary 'genomics' root specified
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_flowcellrun()
+        test_object = annotator._init_flowcellrun()
 
         # THEN the flowcell run object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.FlowcellRun)
-        assert (testobject._id == mockid)
-        assert testobject.is_mapped
+        assert (type(test_object) == docs.FlowcellRun)
+        assert (test_object._id == mock_id)
+        assert test_object.is_mapped
 
     def test_init_flowcellrun_for_new_run(self, mock_db):
         # GIVEN a flowcell run ID and a connection to a database in which
         # a document corresponding to the flowcell run does not exist
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
 
         # AND an annotator object is created for the flowcell run with
         # an arbitrary 'genomics' root specified
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_flowcellrun()
+        test_object = annotator._init_flowcellrun()
 
         # THEN the new flowcell run object should be returned
-        assert (type(testobject) == docs.FlowcellRun)
-        assert (testobject._id == mockid)
-        assert not testobject.is_mapped
+        assert (type(test_object) == docs.FlowcellRun)
+        assert (test_object._id == mock_id)
+        assert not test_object.is_mapped
 
     def test_get_flowcell_path_for_existing_folder(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at the path 'genomics/Illumina/<run_id>'
-        mockid = '161231_INSTID_0001_AC00000XX'
-        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the flowcell folder path is retrieved
         testpath = annotator._get_flowcell_path()
 
         # THEN correct flowcell folder should be found in 'genomics/Illumina/'
-        assert (testpath == str(mockpath))
+        assert (testpath == str(mock_path))
 
     def test_get_flowcell_path_for_invalid_root(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary directory that does not
         # contain 'genomics/Illumina/'
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the flowcell folder path is retrieved
 
@@ -302,50 +302,50 @@ class TestFlowcellRunAnnotator:
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        mockid = '161231_INSTID_0001_AC00000XX'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
                     .mkdir('Unaligned'))
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the flowcell folder path is retrieved
         testpath = annotator._get_unaligned_path()
 
         # THEN correct flowcell folder should be found in 'genomics/Illumina/'
-        assert (testpath == str(mockpath))
+        assert (testpath == str(mock_path))
 
     def test_get_unaligned_path_for_missing_folder(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and there is no subfolder named 'Unaligned'
-        mockid = '161231_INSTID_0001_AC00000XX'
-        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the unaligned folder path is retrieved
 
@@ -355,116 +355,116 @@ class TestFlowcellRunAnnotator:
 
     def test_get_flowcell_run(self, mock_db):
         # GIVEN any state and a flowcell run annotator object
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN model object is retrieved
-        testobject = annotator.get_flowcell_run()
+        test_object = annotator.get_flowcell_run()
 
         # THEN should be expected object
-        assert (testobject == mockobject)
+        assert (test_object == mock_object)
 
     def test_get_projects(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
 
         # AND the unaligned folder includes multiple project folders
-        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
                     .mkdir('Unaligned'))
-        for p in mockprojects:
-            mockpath.mkdir(p)
+        for p in mock_projects:
+            mock_path.mkdir(p)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN list of projects is retrieved
-        testprojects = annotator.get_projects()
+        test_projects = annotator.get_projects()
 
         # THEN the list of projects should include all project folders
         # in the unaligned folder (and nothing else)
-        assert (testprojects == mockprojects)
+        assert (test_projects == mock_projects)
 
     def test_get_libraries(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
 
         # AND the unaligned folder includes multiple project folders,
         # each with multiple folders for sequenced libraries
-        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
-        mocklibs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_libs = {0: ['lib1111-11111111', 'lib2222-22222222'],
                     1: ['lib3333-33333333', 'lib4444-44444444']}
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
-                    .mkdir('Unaligned'))
-        for idx, p in enumerate(mockprojects):
-            projpath = mockpath.mkdir(p)
-            for l in mocklibs[idx]:
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
+                     .mkdir('Unaligned'))
+        for idx, p in enumerate(mock_projects):
+            projpath = mock_path.mkdir(p)
+            for l in mock_libs[idx]:
                 projpath.mkdir(l)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the full list of unaligned libraries is retrieved
-        testlibs = annotator.get_libraries()
+        test_libs = annotator.get_libraries()
 
         # THEN the list should include all library folders across all projects
         # in the unaligned folder (and nothing else)
-        assert (set(testlibs) ==
-                set([l for libs in mocklibs.values() for l in libs]))
+        assert (set(test_libs) ==
+                set([l for libs in mock_libs.values() for l in libs]))
 
     def test_get_sequenced_libraries(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        mockid = '161231_INSTID_0001_AC00000XX'
+        mock_id = '161231_INSTID_0001_AC00000XX'
 
         # AND the unaligned folder includes multiple project folders,
         # each with multiple folders for sequenced libraries that contain
         # one or more FASTQ files for the library
-        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
-        mocklibs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_libs = {0: ['lib1111-11111111', 'lib2222-22222222'],
                     1: ['lib3333-33333333', 'lib4444-44444444']}
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
                     .mkdir('Unaligned'))
-        for idx, p in enumerate(mockprojects):
-            projpath = mockpath.mkdir(p)
-            for l in mocklibs[idx]:
+        for idx, p in enumerate(mock_projects):
+            projpath = mock_path.mkdir(p)
+            for l in mock_libs[idx]:
                 libpath = projpath.mkdir(l)
                 libpath.ensure('sample-name_S001_L001_R1_001.fastq.gz')
                 libpath.ensure('sample-name_S001_L002_R1_001.fastq.gz')
@@ -472,45 +472,46 @@ class TestFlowcellRunAnnotator:
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=mockid,
+            run_id=mock_id,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
 
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
-        mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = mockid
-        annotator.flowcellrun = mockobject
+        mock_object = mock.create_autospec(docs.FlowcellRun)
+        mock_object._id = mock_id
+        annotator.flowcellrun = mock_object
 
         # WHEN the full list of sequenced library model objects is retrieved
-        testobjects = annotator.get_sequenced_libraries()
+        test_objects = annotator.get_sequenced_libraries()
 
         # THEN the list should include a sequenced library model object
         # corresponding to each library in the unaligned folder;
         # note: library IDs correspond to library folder names without any
         # of the numbers following the dash, and library IDs for each
         # sequenced library is be stored in the 'parent_id' attribute
-        assert (all[type(sl) == docs.SequencedLibrary] for sl in testobjects)
-        assert (set([sl.parent_id for sl in testobjects]) ==
-                set([l.split('-')[0] for libs in mocklibs.values()
+        assert (all[type(sl) == docs.SequencedLibrary] for sl in test_objects)
+        assert (set([sl.parent_id for sl in test_objects]) ==
+                set([l.split('-')[0] for libs in mock_libs.values()
                      for l in libs]))
 
 
 @pytest.fixture(scope='function')
-def mockbatchfile(filename, tmpdir):
-    mockcontents = ['###METADATA\n',
-                    '#############\n',
-                    'Workflow Name\toptimized_workflow_1\n',
-                    'Project Name\t161231_P00-00_C00000XX\n',
-                    '###TABLE DATA\n',
-                    '#############\n',
-                    'SampleName\tin_tag##_::_::_::param_name\n',
-                    'sample1\tin_value1\n',
-                    'sample2\tin_value2\n']
-    mockfile = tmpdir.join(filename)
-    mockfile.write(''.join(mockcontents))
-    return str(mockfile)
+def mock_batchfile(filename, tmpdir):
+    # GIVEN a simplified workflow batch content with protypical contents
+    mock_contents = ['###METADATA\n',
+                     '#############\n',
+                     'Workflow Name\toptimized_workflow_1\n',
+                     'Project Name\t161231_P00-00_C00000XX\n',
+                     '###TABLE DATA\n',
+                     '#############\n',
+                     'SampleName\tin_tag##_::_::_::param_name\n',
+                     'sample1\tin_value1\n',
+                     'sample2\tin_value2\n']
+    mock_file = tmpdir.join(filename)
+    mock_file.write(''.join(mock_contents))
+    return str(mock_file)
 
 
 class TestWorkflowBatchAnnotator:
@@ -521,41 +522,41 @@ class TestWorkflowBatchAnnotator:
     def test_init_workflowbatch_for_existing_workflowbatch(self, mock_db,
                                                            tmpdir):
         # GIVEN a workflow batch ID and path to the workflow batch file
-        mockid = 'globusgalaxy_2016-12-31_1'
-        mockfilename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
-        mockfile = mockbatchfile(mockfilename, tmpdir)
+        mock_id = 'globusgalaxy_2016-12-31_1'
+        mock_filename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
+        mock_file = mock_batchfile(mock_filename, tmpdir)
 
         # AND a connection to a database in which a document corresponding
         # to the workflow batch exists already
         mock_db.workflowbatches.insert_one(
-            {'_id': mockid,
-             'workflowbatchFile': mockfile,
+            {'_id': mock_id,
+             'workflowbatchFile': mock_file,
              'date': datetime.datetime(2016, 12, 31, 0, 0),
              'type': 'Galaxy workflow batch'})
 
         # AND an annotator object is created for the workflow batch with
         # an arbitrary 'genomics' root specified
         annotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=mockfile,
+            workflowbatch_file=mock_file,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_workflowbatch()
+        test_object = annotator._init_workflowbatch()
 
         # THEN the workflow batch object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.GalaxyWorkflowBatch)
-        assert (testobject._id == mockid)
-        assert testobject.is_mapped
+        assert (type(test_object) == docs.GalaxyWorkflowBatch)
+        assert (test_object._id == mock_id)
+        assert test_object.is_mapped
 
     def test_init_workflowbatch_for_new_workflowbatch(self, mock_db,
                                                            tmpdir):
         # GIVEN a path to a workflow batch file
-        mockid = 'globusgalaxy_2016-12-31_1'
-        mockfilename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
-        mockfile = mockbatchfile(mockfilename, tmpdir)
+        mock_id = 'globusgalaxy_2016-12-31_1'
+        mock_filename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
+        mock_file = mock_batchfile(mock_filename, tmpdir)
 
         # AND a connection to a database in which a document corresponding
         # to the workflow batch does not exist
@@ -563,27 +564,27 @@ class TestWorkflowBatchAnnotator:
         # AND an annotator object is created for the workflow batch with
         # an arbitrary 'genomics' root specified
         annotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=mockfile,
+            workflowbatch_file=mock_file,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_workflowbatch()
+        test_object = annotator._init_workflowbatch()
 
         # THEN the workflow batch object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.GalaxyWorkflowBatch)
-        assert (testobject._id == mockid)
-        assert not testobject.is_mapped
+        assert (type(test_object) == docs.GalaxyWorkflowBatch)
+        assert (test_object._id == mock_id)
+        assert not test_object.is_mapped
 
     def test_update_workflowbatch(self, mock_db, tmpdir):
         # GIVEN an annotator object created for a workflow batch with
         # associated workflow batch file
-        mockfilename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
-        mockfile = mockbatchfile(mockfilename, tmpdir)
+        mock_filename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
+        mock_file = mock_batchfile(mock_filename, tmpdir)
         annotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=mockfile,
+            workflowbatch_file=mock_file,
             db=mock_db,
             genomics_root='/mnt'
         )
@@ -599,29 +600,29 @@ class TestWorkflowBatchAnnotator:
     def test_get_workflow_batch(self, mock_db, tmpdir):
         # GIVEN an annotator object created for a workflow batch with
         # associated workflow batch file
-        mockfilename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
-        mockfile = mockbatchfile(mockfilename, tmpdir)
+        mock_filename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
+        mock_file = mock_batchfile(mock_filename, tmpdir)
         annotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=mockfile,
+            workflowbatch_file=mock_file,
             db=mock_db,
             genomics_root='/mnt'
         )
 
         # WHEN the mapped model object is retrieved
-        testobject = annotator.get_workflow_batch()
+        test_object = annotator.get_workflow_batch()
 
         # THEN the model object should now have expected fields including
         # for projects, and should no longer be flagged as mapped
-        assert (testobject.projects == ['P00-00'])
-        assert not testobject.is_mapped
+        assert (test_object.projects == ['P00-00'])
+        assert not test_object.is_mapped
 
     def test_get_sequenced_libraries(self, mock_db, tmpdir):
         # GIVEN an annotator object created for a workflow batch with
         # associated workflow batch file
-        mockfilename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
-        mockfile = mockbatchfile(mockfilename, tmpdir)
+        mock_filename = '161231_P00-00_C00000XX_optimized_workflow_1.txt'
+        mock_file = mock_batchfile(mock_filename, tmpdir)
         annotator = annotation.WorkflowBatchAnnotator(
-            workflowbatch_file=mockfile,
+            workflowbatch_file=mock_file,
             db=mock_db,
             genomics_root='/mnt'
         )
@@ -639,15 +640,15 @@ class TestWorkflowBatchAnnotator:
 
 
 @pytest.fixture(scope='function')
-def mockbatchdata():
-    mockid = 'lib1111_C00000XX'
+def mock_batchdata():
+    mock_id = 'lib1111_C00000XX'
     yield (
-        mockid,
+        mock_id,
         [
             {'name': 'SampleName',
              'tag': 'SampleName',
              'type': 'sample',
-             'value': mockid},
+             'value': mock_id},
             {'name': 'to_path',
              'tag': 'out-source1_out-type1_out-ext_out',
              'type': 'output',
@@ -670,69 +671,69 @@ class TestProcessedLibraryAnnotator:
     `bripipetools.annotation.globusgalaxy` module.
     """
     def test_init_processedlibrary_for_existing_sample(self, mock_db,
-                                                       mockbatchdata):
+                                                       mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library exists already
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         mock_db.samples.insert_one(
-            {'_id': '{}_processed'.format(mockid),
+            {'_id': '{}_processed'.format(mock_id),
              'type': 'processed library'}
         )
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_processedlibrary()
+        test_object = annotator._init_processedlibrary()
 
         # THEN the processed library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.ProcessedLibrary)
-        assert (testobject._id == '{}_processed'.format(mockid))
-        assert testobject.is_mapped
+        assert (type(test_object) == docs.ProcessedLibrary)
+        assert (test_object._id == '{}_processed'.format(mock_id))
+        assert test_object.is_mapped
 
     def test_init_processedlibrary_for_new_sample(self, mock_db,
-                                                  mockbatchdata):
+                                                  mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
         # WHEN the model object is initiated for the annotator
-        testobject = annotator._init_processedlibrary()
+        test_object = annotator._init_processedlibrary()
 
         # THEN the processed library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(testobject) == docs.ProcessedLibrary)
-        assert (testobject._id == '{}_processed'.format(mockid))
-        assert not testobject.is_mapped
+        assert (type(test_object) == docs.ProcessedLibrary)
+        assert (test_object._id == '{}_processed'.format(mock_id))
+        assert not test_object.is_mapped
 
-    def test_get_outputs(self, mock_db, mockbatchdata):
+    def test_get_outputs(self, mock_db, mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
@@ -746,17 +747,17 @@ class TestProcessedLibraryAnnotator:
                     'out-source2_out-type1_out-ext_out': 'outfilepath2',
                     'out-source3_out-type2_out-ext_out': 'outfilepath3'})
 
-    def test_group_outputs(self, mock_db, mockbatchdata):
+    def test_group_outputs(self, mock_db, mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
@@ -782,17 +783,17 @@ class TestProcessedLibraryAnnotator:
                     ]
                 })
 
-    def test_append_processed_data_first_time(self, mock_db, mockbatchdata):
+    def test_append_processed_data_first_time(self, mock_db, mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
@@ -802,26 +803,26 @@ class TestProcessedLibraryAnnotator:
         # THEN outputs annotated in separate dicts according to source, name,
         # and file path, grouped into lists for each output type
         assert (annotator.processedlibrary.processed_data[0]['workflowbatch_id']
-                == mockbatchid)
+                == mock_batchid)
 
     def test_append_processed_data_previously_processed(self, mock_db,
-                                                        mockbatchdata):
+                                                        mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
         # AND processed data for the workflow batch are already present
         annotator.processedlibrary.processed_data.append(
-            {'workflowbatch_id': mockbatchid,
+            {'workflowbatch_id': mock_batchid,
              'outputs': []}
         )
 
@@ -831,19 +832,19 @@ class TestProcessedLibraryAnnotator:
         # THEN outputs annotated in separate dicts according to source, name,
         # and file path, grouped into lists for each output type
         assert (annotator.processedlibrary.processed_data[0]['workflowbatch_id']
-                == mockbatchid)
+                == mock_batchid)
 
-    def test_update_processedlibrary(self, mock_db, mockbatchdata):
+    def test_update_processedlibrary(self, mock_db, mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
@@ -853,28 +854,28 @@ class TestProcessedLibraryAnnotator:
         # THEN the model object should now have expected fields including
         # for processed data and parent ID, and should no longer be flagged
         # as mapped
-        assert (annotator.processedlibrary.parent_id == mockid)
+        assert (annotator.processedlibrary.parent_id == mock_id)
         assert not annotator.processedlibrary.is_mapped
 
-    def test_get_processed_library(self, mock_db, mockbatchdata):
+    def test_get_processed_library(self, mock_db, mock_batchdata):
         # GIVEN a processed library ID and a connection to a database in which
         # a document corresponding to the processed library does not exist
-        mockid, mockparams = mockbatchdata
+        mock_id, mock_params = mock_batchdata
 
         # AND an annotator object is created for the processed library with
         # workflow batch ID and workflow parameters for that sample
-        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        mock_batchid = 'globusgalaxy_2016-12-31_1'
         annotator = annotation.ProcessedLibraryAnnotator(
-            workflowbatch_id=mockbatchid,
-            params=mockparams,
+            workflowbatch_id=mock_batchid,
+            params=mock_params,
             db=mock_db
         )
 
         # WHEN the mapped model object is retrieved
-        testobject = annotator.get_processed_library()
+        test_object = annotator.get_processed_library()
 
         # THEN the model object should have expected fields including
         # for processed data and parent ID, and should no longer be flagged
         # as mapped
-        assert (testobject.parent_id == mockid)
-        assert not testobject.is_mapped
+        assert (test_object.parent_id == mock_id)
+        assert not test_object.is_mapped

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -56,16 +56,16 @@ class TestFlowcellRunAnnotator:
     def test_init_flowcellrun_for_existing_run(self, mock_db):
         # GIVEN a flowcell run ID and a connection to a database in which
         # a document corresponding to the flowcell run exists already
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
         mock_db.runs.insert_one(
-            {'_id': testid,
+            {'_id': mockid,
              'type': 'flowcell'}
         )
 
         # AND an annotator object is created for the flowcell run with
         # an arbitrary 'genomics' root specified
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root='/mnt'
         )
@@ -76,18 +76,18 @@ class TestFlowcellRunAnnotator:
         # THEN the flowcell run object should be returned and
         # should be correctly mapped from the database object
         assert (type(modelobject) == docs.FlowcellRun)
-        assert (modelobject._id == testid)
+        assert (modelobject._id == mockid)
         assert modelobject.is_mapped
 
     def test_init_flowcellrun_for_new_run(self, mock_db):
         # GIVEN a flowcell run ID and a connection to a database in which
         # a document corresponding to the flowcell run does not exist
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
 
         # AND an annotator object is created for the flowcell run with
         # an arbitrary 'genomics' root specified
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root='/mnt'
         )
@@ -97,19 +97,19 @@ class TestFlowcellRunAnnotator:
 
         # THEN the new flowcell run object should be returned
         assert (type(modelobject) == docs.FlowcellRun)
-        assert (modelobject._id == testid)
+        assert (modelobject._id == mockid)
         assert not modelobject.is_mapped
 
     def test_get_flowcell_path_for_existing_folder(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at the path 'genomics/Illumina/<run_id>'
-        testid = '161231_INSTID_0001_AC00000XX'
-        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+        mockid = '161231_INSTID_0001_AC00000XX'
+        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -117,7 +117,7 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN the flowcell folder path is retrieved
@@ -129,12 +129,12 @@ class TestFlowcellRunAnnotator:
     def test_get_flowcell_path_for_invalid_root(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary directory that does not
         # contain 'genomics/Illumina/'
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -142,7 +142,7 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN the flowcell folder path is retrieved
@@ -155,14 +155,14 @@ class TestFlowcellRunAnnotator:
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        testid = '161231_INSTID_0001_AC00000XX'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+        mockid = '161231_INSTID_0001_AC00000XX'
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
                     .mkdir('Unaligned'))
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -170,7 +170,7 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN the flowcell folder path is retrieved
@@ -183,13 +183,13 @@ class TestFlowcellRunAnnotator:
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and there is no subfolder named 'Unaligned'
-        testid = '161231_INSTID_0001_AC00000XX'
-        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+        mockid = '161231_INSTID_0001_AC00000XX'
+        mockpath = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
 
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -197,7 +197,7 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN the unaligned folder path is retrieved
@@ -208,9 +208,9 @@ class TestFlowcellRunAnnotator:
 
     def test_get_flowcell_run(self, mock_db):
         # GIVEN any state and a flowcell run annotator object
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root='/mnt'
         )
@@ -218,7 +218,7 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN model object is retrieved
@@ -231,9 +231,11 @@ class TestFlowcellRunAnnotator:
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
+
+        # AND the unaligned folder includes multiple project folders
         mockprojects = ['P1-1-11111111', 'P99-99-99999999']
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
                     .mkdir('Unaligned'))
         for p in mockprojects:
             mockpath.mkdir(p)
@@ -241,7 +243,7 @@ class TestFlowcellRunAnnotator:
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -249,24 +251,28 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
         # WHEN list of projects is retrieved
         testprojects = annotator.get_projects()
 
-        # THEN
+        # THEN the list of projects should include all project folders
+        # in the unaligned folder (and nothing else)
         assert (testprojects == mockprojects)
 
     def test_get_libraries(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
         # under which a folder exists at 'genomics/Illumina/<run_id>',
         # and that folder contains a subfolder named 'Unaligned'
-        testid = '161231_INSTID_0001_AC00000XX'
+        mockid = '161231_INSTID_0001_AC00000XX'
+
+        # AND the unaligned folder includes multiple project folders,
+        # each with multiple folders for sequenced libraries
         mockprojects = ['P1-1-11111111', 'P99-99-99999999']
         mocklibs = {0: ['lib1111-11111111', 'lib2222-22222222'],
                     1: ['lib3333-33333333', 'lib4444-44444444']}
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(testid)
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
                     .mkdir('Unaligned'))
         for idx, p in enumerate(mockprojects):
             projpath = mockpath.mkdir(p)
@@ -276,7 +282,7 @@ class TestFlowcellRunAnnotator:
         # AND an annotator object created for a flowcell run ID with that
         # directory specified as 'genomics' root
         annotator = annotation.FlowcellRunAnnotator(
-            run_id=testid,
+            run_id=mockid,
             db=mock_db,
             genomics_root=str(tmpdir)
         )
@@ -284,160 +290,65 @@ class TestFlowcellRunAnnotator:
         # AND the annotator object has a mapped model object with the
         # corresponding run ID
         mockobject = mock.create_autospec(docs.FlowcellRun)
-        mockobject._id = testid
+        mockobject._id = mockid
         annotator.flowcellrun = mockobject
 
-        # WHEN list of projects is retrieved
+        # WHEN the full list of unaligned libraries is retrieved
         testlibs = annotator.get_libraries()
 
-        # THEN
-        assert (testlibs == [l for libs in mocklibs.values() for l in libs])
+        # THEN the list should include all library folders across all projects
+        # in the unaligned folder (and nothing else)
+        assert (set(testlibs) ==
+                set([l for libs in mocklibs.values() for l in libs]))
 
-#     def test_init_flowcellrun_existing_run(self, annotatordata, mock_db):
-#         # (GIVEN)
-#         (annotator, rundata) = annotatordata
-#
-#         logger.info("test `_init_flowcellrun()` with existing run")
-#
-#         # WHEN flowcell run already exists in 'runs' collection
-#         mock_db.runs.insert_one(
-#             {'_id': rundata['run_id'],
-#              'type': 'flowcell',
-#              'isMock': True})
-#         flowcellrun = annotator._init_flowcellrun()
-#
-#         # THEN the flowcell run object should be returned and
-#         # should be correctly mapped from the database object
-#         assert(type(flowcellrun) == docs.FlowcellRun)
-#         assert(flowcellrun._id == rundata['run_id'])
-#         assert(hasattr(flowcellrun, 'is_mock'))
-#
-#         logger.info("[rollback] remove most recently inserted "
-#                     "from mock database")
-#         mock_db.runs.drop()
-#
-#     def test_init_flowcellrun_new_run(self, annotatordata):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         logger.info("test `_init_flowcellrun()` with new run")
-#
-#         # WHEN flowcell run run does not already exist in
-#         # 'runs' collection
-#         flowcellrun = annotator._init_flowcellrun()
-#
-#         # THEN a new flowcell run object should be returned
-#         assert(type(flowcellrun) == docs.FlowcellRun)
-#         assert(flowcellrun._id == rundata['run_id'])
-#         assert(not hasattr(flowcellrun, 'is_mock'))
-# #
-#     def test_get_flowcell_path(self, annotatordata, mock_genomics_server):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         logger.info("test `_get_flowcell_path()`")
-#
-#         # WHEN searching for flowcell run ID in 'genomics' path
-#
-#         # THEN correct flowcell folder should be found in 'genomics/Illumina/'
-#         assert(annotator._get_flowcell_path() == rundata['path'])
-#
-#     def test_get_unaligned_path(self, annotatordata, mock_genomics_server):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         logger.info("test `_get_unaligned_path()`")
-#
-#         # WHEN searching for 'Unaligned' folder
-#
-#         # THEN path returned should be 'genomics/Illumina/<run_id>/Unaligned'
-#         assert(annotator._get_unaligned_path() == rundata['unaligned']['path'])
-#
-#     def test_get_projects(self, annotatordata, mock_genomics_server):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         logger.info("test `_get_projects()`")
-#
-#         # WHEN listing unaligned projects
-#         projects = annotator.get_projects()
-#
-#         # THEN should find expected number of projects
-#         assert(len(projects) == len(rundata['unaligned']['projects']))
-#
-#     @pytest.mark.parametrize("projectnum", [0, 1, 2])
-#     def test_get_libraries_single_project(self, annotatordata,
-#                                           mock_genomics_server, projectnum):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         # AND unaligned samples for a single project
-#         projectdata = rundata['unaligned']['projects'][projectnum]
-#
-#         logger.info("test `_get_libraries()`, single project ({})"
-#                     .format(projectdata['name']))
-#
-#         # WHEN listing libraries for the project
-#         libraries = annotator.get_libraries(projectdata['name'])
-#
-#         # THEN should find the expected number of libaries (samples)
-#         assert(len(libraries) == len(projectdata['samples']))
-#
-#     def test_get_libraries_all_projects(self, annotatordata,
-#                                         mock_genomics_server):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         # AND list of unaligned projects
-#         projects = rundata['unaligned']['projects']
-#
-#         logger.info("test `_get_libraries()`, all projects")
-#
-#         # WHEN listing libraries for all projects
-#         libraries = annotator.get_libraries()
-#
-#         # THEN should find expected number of libraries
-#         assert(len(libraries)
-#                 == sum(map(lambda x: len(x['samples']), projects)))
-#
-#     @pytest.mark.parametrize("projectnum", [0, 1, 2])
-#     def test_get_sequenced_libraries_single_project(self, annotatordata,
-#                                                     mock_genomics_server,
-#                                                     projectnum):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         # AND unaligned samples for a single project
-#         projectdata = rundata['unaligned']['projects'][projectnum]
-#
-#         logger.info("test `get_sequenced_libraries()`, single project ({})"
-#                     .format(projectdata['name']))
-#
-#         # WHEN collecting sequenced libraries for project
-#         sequencedlibraries = annotator.get_sequenced_libraries(
-#             projectdata['name'])
-#
-#         # THEN should find excpeted number of sequenced libraries
-#         assert(len(sequencedlibraries) == len(projectdata['samples']))
-#
-#     def test_get_sequenced_libraries_all_projects(self, annotatordata,
-#                                                   mock_genomics_server):
-#         # (GIVEN)
-#         annotator, rundata = annotatordata
-#
-#         # AND list of unaligned projects
-#         projects = rundata['unaligned']['projects']
-#
-#         logger.info("test `get_sequenced_libraries()`, all projects")
-#
-#         # WHEN collecting sequenced libraries for all projects
-#         sequencedlibraries = annotator.get_sequenced_libraries()
-#
-#         # THEN should find 31 total libraries
-#         assert(len(sequencedlibraries)
-#                == sum(map(lambda x: len(x['samples']), projects)))
-#
-#
+    def test_get_sequenced_libraries(self, mock_db, tmpdir):
+        # GIVEN a flowcell run ID and an arbitrary root directory,
+        # under which a folder exists at 'genomics/Illumina/<run_id>',
+        # and that folder contains a subfolder named 'Unaligned'
+        mockid = '161231_INSTID_0001_AC00000XX'
+
+        # AND the unaligned folder includes multiple project folders,
+        # each with multiple folders for sequenced libraries that contain
+        # one or more FASTQ files for the library
+        mockprojects = ['P1-1-11111111', 'P99-99-99999999']
+        mocklibs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+                    1: ['lib3333-33333333', 'lib4444-44444444']}
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mockid)
+                    .mkdir('Unaligned'))
+        for idx, p in enumerate(mockprojects):
+            projpath = mockpath.mkdir(p)
+            for l in mocklibs[idx]:
+                libpath = projpath.mkdir(l)
+                libpath.ensure('sample-name_S001_L001_R1_001.fastq.gz')
+                libpath.ensure('sample-name_S001_L002_R1_001.fastq.gz')
+
+        # AND an annotator object created for a flowcell run ID with that
+        # directory specified as 'genomics' root
+        annotator = annotation.FlowcellRunAnnotator(
+            run_id=mockid,
+            db=mock_db,
+            genomics_root=str(tmpdir)
+        )
+
+        # AND the annotator object has a mapped model object with the
+        # corresponding run ID
+        mockobject = mock.create_autospec(docs.FlowcellRun)
+        mockobject._id = mockid
+        annotator.flowcellrun = mockobject
+
+        # WHEN the full list of sequenced library model objects is retrieved
+        testseqlibs = annotator.get_sequenced_libraries()
+
+        # THEN the list should include a sequenced library model object
+        # corresponding to each library in the unaligned folder;
+        # note: library IDs correspond to library folder names without any
+        # of the numbers following the dash, and library IDs for each
+        # sequenced library is be stored in the 'parent_id' attribute
+        assert (all[type(sl) == docs.SequencedLibrary] for sl in testseqlibs)
+        assert (set([sl.parent_id for sl in testseqlibs]) ==
+                set([l.split('-')[0] for libs in mocklibs.values()
+                     for l in libs]))
+
 # @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
 # class TestSequencedLibraryAnnotator:
 #     """

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope='function')
-def mock_db(request):
+def mock_db():
     # GIVEN a mocked version of the TG3 Mongo database
     logger.info(("[setup] mock database, connect "
                  "to mock Mongo database"))
@@ -53,13 +53,13 @@ class TestSequencedLibraryAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_sequencedlibrary()
+        testobject = annotator._init_sequencedlibrary()
 
         # THEN the sequenced library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(modelobject) == docs.SequencedLibrary)
-        assert (modelobject._id == mockid)
-        assert modelobject.is_mapped
+        assert (type(testobject) == docs.SequencedLibrary)
+        assert (testobject._id == mockid)
+        assert testobject.is_mapped
 
     def test_init_sequencedlibrary_for_existing_sample(self, mock_db):
         # GIVEN a sequenced library ID and a connection to a database in which
@@ -81,13 +81,13 @@ class TestSequencedLibraryAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_sequencedlibrary()
+        testobject = annotator._init_sequencedlibrary()
 
         # THEN the sequenced library object should be returned and
         # should be correctly mapped from the database object
-        assert (type(modelobject) == docs.SequencedLibrary)
-        assert (modelobject._id == mockid)
-        assert not modelobject.is_mapped
+        assert (type(testobject) == docs.SequencedLibrary)
+        assert (testobject._id == mockid)
+        assert not testobject.is_mapped
 
     def test_get_raw_data(self, mock_db, tmpdir):
         # GIVEN an annotator object created for the sequenced library with
@@ -218,13 +218,13 @@ class TestFlowcellRunAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_flowcellrun()
+        testobject = annotator._init_flowcellrun()
 
         # THEN the flowcell run object should be returned and
         # should be correctly mapped from the database object
-        assert (type(modelobject) == docs.FlowcellRun)
-        assert (modelobject._id == mockid)
-        assert modelobject.is_mapped
+        assert (type(testobject) == docs.FlowcellRun)
+        assert (testobject._id == mockid)
+        assert testobject.is_mapped
 
     def test_init_flowcellrun_for_new_run(self, mock_db):
         # GIVEN a flowcell run ID and a connection to a database in which
@@ -240,12 +240,12 @@ class TestFlowcellRunAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_flowcellrun()
+        testobject = annotator._init_flowcellrun()
 
         # THEN the new flowcell run object should be returned
-        assert (type(modelobject) == docs.FlowcellRun)
-        assert (modelobject._id == mockid)
-        assert not modelobject.is_mapped
+        assert (type(testobject) == docs.FlowcellRun)
+        assert (testobject._id == mockid)
+        assert not testobject.is_mapped
 
     def test_get_flowcell_path_for_existing_folder(self, mock_db, tmpdir):
         # GIVEN a flowcell run ID and an arbitrary root directory,
@@ -542,13 +542,13 @@ class TestWorkflowBatchAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_workflowbatch()
+        testobject = annotator._init_workflowbatch()
 
         # THEN the workflow batch object should be returned and
         # should be correctly mapped from the database object
-        assert (type(modelobject) == docs.GalaxyWorkflowBatch)
-        assert (modelobject._id == mockid)
-        assert modelobject.is_mapped
+        assert (type(testobject) == docs.GalaxyWorkflowBatch)
+        assert (testobject._id == mockid)
+        assert testobject.is_mapped
 
     def test_init_workflowbatch_for_new_workflowbatch(self, mock_db,
                                                            tmpdir):
@@ -569,13 +569,13 @@ class TestWorkflowBatchAnnotator:
         )
 
         # WHEN the model object is initiated for the annotator
-        modelobject = annotator._init_workflowbatch()
+        testobject = annotator._init_workflowbatch()
 
         # THEN the workflow batch object should be returned and
         # should be correctly mapped from the database object
-        assert (type(modelobject) == docs.GalaxyWorkflowBatch)
-        assert (modelobject._id == mockid)
-        assert not modelobject.is_mapped
+        assert (type(testobject) == docs.GalaxyWorkflowBatch)
+        assert (testobject._id == mockid)
+        assert not testobject.is_mapped
 
     def test_update_workflowbatch(self, mock_db, tmpdir):
         # GIVEN an annotator object created for a workflow batch with
@@ -638,246 +638,243 @@ class TestWorkflowBatchAnnotator:
     # TODO: test_get_processed_libraries
 
 
-# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-# class TestProcessedLibraryAnnotator:
-#     """
-#     Tests methods for the `ProcessedLibraryAnnotator` class in the
-#     `bripipetools.annotation.globusgalaxy` module.
-#     """
-#     @pytest.fixture(
-#         scope='class',
-#         params=[{'runnum': r, 'batchnum': b, 'samplenum': s}
-#                 for r in range(1)
-#                 for b in range(2)
-#                 for s in range(6)
-#                 if not (b == 1 and s > 2)])
-#     @pytest.fixture(scope='class')
-#     def annotatordata(self, request, mock_genomics_server, mock_db):
-#         # GIVEN a ProcessedLibraryAnnotator with mock 'genomics' server path,
-#         # and path to library folder (i.e., where data/organization is known),
-#         # with specified library, project, and run ID,
-#         # as well as a mock db connection
-#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-#         rundata = runs[request.param['runnum']]
-#         batches = rundata['submitted']['batches']
-#         batchdata = batches[request.param['batchnum']]
-#         samples = batchdata['samples']
-#         samplename = samples[request.param['samplenum']]
-#         proclib_id = ('{}_{}_processed'
-#                       .format(samplename, rundata['flowcell_id']))
-#
-#         logger.info("[setup] ProcessedLibraryAnnotator mock instance "
-#                     "for sample {}".format(samplename))
-#
-#         workflowbatch_id = batchdata['id']
-#         # TODO: try to remove the test dependency on the io module here
-#         workflowbatch_data = io.WorkflowBatchFile(
-#             path=batchdata['path'],
-#             state='submit').parse()
-#
-#         proclibannotator = annotation.ProcessedLibraryAnnotator(
-#             workflowbatch_id=workflowbatch_id,
-#             params=workflowbatch_data['samples'][request.param['samplenum']],
-#             db=mock_db)
-#
-#         def fin():
-#             logger.info("[teardown] ProcessedLibraryAnnotator mock instance")
-#         request.addfinalizer(fin)
-#         return (proclibannotator, batchdata, proclib_id)
-#
-#     def test_init_attribute_munging(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, proclib_id = annotatordata
-#
-#         logger.info("test `__init__()` for proper attribute munging "
-#                     " with sample {}".format(proclib_id))
-#
-#         # WHEN checking whether input arguments were automatically munged
-#         # when setting annotator attributes
-#
-#         # THEN the processed library ID should be properly constructed as the
-#         # library ID and flowcell ID, tagged as processed
-#         assert(annotator.proclib_id == proclib_id)
-#
-#     def test_init_processedlibrary_existing_sample(self, annotatordata,
-#                                                    mock_db):
-#         # (GIVEN)
-#         annotator, _, proclib_id = annotatordata
-#
-#         logger.info("test `_init_processedlibrary()` with existing sample {}"
-#                     .format(proclib_id))
-#
-#         # WHEN processed library already exists in 'samples' collection
-#         mock_db.samples.insert_one(
-#             {'_id': proclib_id,
-#              'type': 'processed library',
-#              'isMock': True})
-#         processedlibrary = annotator._init_processedlibrary()
-#
-#         # THEN the processed library object should be returned and
-#         # should be correctly mapped from the database object
-#         assert(type(processedlibrary) == docs.ProcessedLibrary)
-#         assert(processedlibrary._id == proclib_id)
-#         assert(hasattr(processedlibrary, 'is_mock'))
-#
-#         logger.info("[rollback] remove most recently inserted "
-#                     "from mock database")
-#         mock_db.samples.drop()
-#
-#     def test_init_processedlibrary_new_sample(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, proclib_id = annotatordata
-#
-#         logger.info("test `_init_processedlibrary()` with new sample")
-#
-#         # WHEN processed library sample does not already exist in
-#         # 'samples' collection
-#         processedlibrary = annotator._init_processedlibrary()
-#
-#         # THEN a new processed library object should be returned
-#         assert(type(processedlibrary) == docs.ProcessedLibrary)
-#         assert(processedlibrary._id == proclib_id)
-#         assert(not hasattr(processedlibrary, 'is_mock'))
-#
-#     def test_get_outputs(self, annotatordata):
-#         # (GIVEN)
-#         annotator, batchdata, proclib_id = annotatordata
-#
-#         logger.info("test `_get_outputs()`")
-#
-#         # WHEN collecting the list of outputs for a processed library
-#
-#         # THEN the outputs should be stored in a dict with expected length
-#         assert(len(annotator._get_outputs()) == batchdata['num_outputs'])
-#
-#     def test_parse_output_name_onepart_source(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_parse_output_name()`, one-part source")
-#
-#         # WHEN parsing output name from workflow batch parameter, and the
-#         # source name has one parts (i.e., 'tophat')
-#         output_items = annotator._parse_output_name(
-#             'tophat_alignments_bam_out')
-#
-#         # THEN output items should be a dictionary including fields for
-#         # name, type, and source
-#         assert(output_items['name'] == 'tophat_alignments_bam')
-#         assert(output_items['type'] == 'alignments')
-#         assert(output_items['source'] == 'tophat')
-#
-#     def test_parse_output_name_twopart_source(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_parse_output_name()`, two-part source")
-#
-#         # WHEN parsing output name from workflow batch parameter, and the
-#         # source name has two parts (i.e., 'picard_rnaseq')
-#         output_items = annotator._parse_output_name(
-#             'picard_rnaseq_metrics_html_out')
-#
-#         # THEN output items should be a dictionary including fields for
-#         # name, type, and source
-#         assert(output_items['name'] == 'picard_rnaseq_metrics_html')
-#         assert(output_items['type'] == 'metrics')
-#         assert(output_items['source'] == 'picard_rnaseq')
-#
-#     def test_group_outputs(self, annotatordata, mock_genomics_server):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_group_outputs()`")
-#
-#         # WHEN collecting the organized dictionary of outputs
-#         outputs = annotator._group_outputs()
-#
-#         # THEN the outputs should be correctly grouped according to type
-#         # and source (tool)
-#         assert(set(outputs.keys())
-#                == set(mock_genomics_server['out_types']))
-#         assert(set([k['source'] for k in outputs['metrics']])
-#                == set(['picard_align', 'tophat_stats', 'picard_markdups',
-#                        'picard_rnaseq', 'htseq']))
-#
-#     def test_append_processed_data(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_append_processed_data()`")
-#
-#         # WHEN batch information and outputs are added to processed data
-#         # field for processed library object
-#         annotator._append_processed_data()
-#
-#         # THEN the length of the processed data field should be 1, containing
-#         # a dictionary with workflow batch ID and outputs
-#         assert(len(annotator.processedlibrary.processed_data) == 1)
-#         assert(set(annotator.processedlibrary.processed_data[0].keys())
-#                == set(['workflowbatch_id', 'outputs']))
-#         annotator.processedlibrary.processed_data = []
-#
-#     def test_append_processed_data_exists(self, annotatordata):
-#         # (GIVEN)
-#         annotator, batchdata, _ = annotatordata
-#
-#         logger.info("test `_append_processed_data()`")
-#
-#         # AND outputs for the workflow batch are already present
-#         annotator.processedlibrary.processed_data.append(
-#             {'workflowbatch_id': batchdata['id'],
-#              'outputs': []})
-#
-#         # WHEN batch information and outputs are added to processed data
-#         # field for processed library object
-#         annotator._append_processed_data()
-#
-#         # THEN the length of the processed data field should be 1, containing
-#         # a dictionary with workflow batch ID and outputs
-#         assert(len(annotator.processedlibrary.processed_data) == 1)
-#         assert(set(annotator.processedlibrary.processed_data[0].keys())
-#                == set(['workflowbatch_id', 'outputs']))
-#         annotator.processedlibrary.processed_data = []
-#
-#     def test_append_processed_data_new(self, annotatordata):
-#         # (GIVEN)
-#         annotator, batchdata, _ = annotatordata
-#
-#         logger.info("test `_append_processed_data()`")
-#
-#         # AND outputs from a different workflow batch are already present
-#         annotator.processedlibrary.processed_data.append(
-#             {'workflowbatch_id': re.sub('\d$',
-#                                         lambda x: str(int(x.group(0)) + 1),
-#                                         batchdata['id']),
-#              'outputs': []})
-#
-#         # WHEN batch information and outputs are added to processed data
-#         # field for processed library object
-#         annotator._append_processed_data()
-#
-#         # THEN the length of the processed data field should be 2, containing
-#         # a dictionary with workflow batch ID and outputs
-#         assert(len(annotator.processedlibrary.processed_data) == 2)
-#         assert(set(annotator.processedlibrary.processed_data[1].keys())
-#                == set(['workflowbatch_id', 'outputs']))
-#         annotator.processedlibrary.processed_data = []
-#
-#     def test_update_processedlibrary(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_update_processedlibrary()`")
-#
-#         # WHEN processed library object is updated
-#         annotator._update_processedlibrary()
-#
-#         # THEN the object should have at least the 'parent_id' and
-#         # 'processed_data', and 'processed_data' should be length 1
-#         assert(all([hasattr(annotator.processedlibrary, field)
-#                     for field in ['parent_id', 'processed_data',
-#                                   'date_created', 'last_updated']]))
-#         assert(len(annotator.processedlibrary.processed_data) == 1)
-#         assert(annotator.processedlibrary.last_updated
-#                > annotator.processedlibrary.date_created)
+@pytest.fixture(scope='function')
+def mockbatchdata():
+    mockid = 'lib1111_C00000XX'
+    yield (
+        mockid,
+        [
+            {'name': 'SampleName',
+             'tag': 'SampleName',
+             'type': 'sample',
+             'value': mockid},
+            {'name': 'to_path',
+             'tag': 'out-source1_out-type1_out-ext_out',
+             'type': 'output',
+             'value': 'outfilepath1'},
+            {'name': 'to_path',
+             'tag': 'out-source2_out-type1_out-ext_out',
+             'type': 'output',
+             'value': 'outfilepath2'},
+            {'name': 'to_path',
+             'tag': 'out-source3_out-type2_out-ext_out',
+             'type': 'output',
+             'value': 'outfilepath3'}
+        ]
+    )
+
+
+class TestProcessedLibraryAnnotator:
+    """
+    Tests methods for the `ProcessedLibraryAnnotator` class in the
+    `bripipetools.annotation.globusgalaxy` module.
+    """
+    def test_init_processedlibrary_for_existing_sample(self, mock_db,
+                                                       mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library exists already
+        mockid, mockparams = mockbatchdata
+
+        mock_db.samples.insert_one(
+            {'_id': '{}_processed'.format(mockid),
+             'type': 'processed library'}
+        )
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN the model object is initiated for the annotator
+        testobject = annotator._init_processedlibrary()
+
+        # THEN the processed library object should be returned and
+        # should be correctly mapped from the database object
+        assert (type(testobject) == docs.ProcessedLibrary)
+        assert (testobject._id == '{}_processed'.format(mockid))
+        assert testobject.is_mapped
+
+    def test_init_processedlibrary_for_new_sample(self, mock_db,
+                                                  mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN the model object is initiated for the annotator
+        testobject = annotator._init_processedlibrary()
+
+        # THEN the processed library object should be returned and
+        # should be correctly mapped from the database object
+        assert (type(testobject) == docs.ProcessedLibrary)
+        assert (testobject._id == '{}_processed'.format(mockid))
+        assert not testobject.is_mapped
+
+    def test_get_outputs(self, mock_db, mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN outputs are retrieved for the processed library
+        testoutputs = annotator._get_outputs()
+
+        # THEN outputs should be stored in a dict with parameter tag and value
+        # as key-value pairs
+        assert (testoutputs
+                == {'out-source1_out-type1_out-ext_out': 'outfilepath1',
+                    'out-source2_out-type1_out-ext_out': 'outfilepath2',
+                    'out-source3_out-type2_out-ext_out': 'outfilepath3'})
+
+    def test_group_outputs(self, mock_db, mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN outputs are grouped by type and source
+        testoutputs = annotator._group_outputs()
+
+        # THEN outputs annotated in separate dicts according to source, name,
+        # and file path, grouped into lists for each output type
+        assert (testoutputs
+                == {
+                    'out-type1': [
+                        {'source': 'out-source1',
+                         'name': 'out-source1_out-type1_out-ext',
+                         'file': 'outfilepath1'},
+                        {'source': 'out-source2',
+                         'name': 'out-source2_out-type1_out-ext',
+                         'file': 'outfilepath2'},
+                    ],
+                    'out-type2': [
+                        {'source': 'out-source3',
+                         'name': 'out-source3_out-type2_out-ext',
+                         'file': 'outfilepath3'},
+                    ]
+                })
+
+    def test_append_processed_data_first_time(self, mock_db, mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN outputs are grouped by type and source
+        annotator._append_processed_data()
+
+        # THEN outputs annotated in separate dicts according to source, name,
+        # and file path, grouped into lists for each output type
+        assert (annotator.processedlibrary.processed_data[0]['workflowbatch_id']
+                == mockbatchid)
+
+    def test_append_processed_data_previously_processed(self, mock_db,
+                                                        mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # AND processed data for the workflow batch are already present
+        annotator.processedlibrary.processed_data.append(
+            {'workflowbatch_id': mockbatchid,
+             'outputs': []}
+        )
+
+        # WHEN outputs are grouped by type and source
+        annotator._append_processed_data()
+
+        # THEN outputs annotated in separate dicts according to source, name,
+        # and file path, grouped into lists for each output type
+        assert (annotator.processedlibrary.processed_data[0]['workflowbatch_id']
+                == mockbatchid)
+
+    def test_update_processedlibrary(self, mock_db, mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN the mapped model object is updated to add any missing fields
+        annotator._update_processedlibrary()
+
+        # THEN the model object should now have expected fields including
+        # for processed data and parent ID, and should no longer be flagged
+        # as mapped
+        assert (annotator.processedlibrary.parent_id == mockid)
+        assert not annotator.processedlibrary.is_mapped
+
+    def test_get_processed_library(self, mock_db, mockbatchdata):
+        # GIVEN a processed library ID and a connection to a database in which
+        # a document corresponding to the processed library does not exist
+        mockid, mockparams = mockbatchdata
+
+        # AND an annotator object is created for the processed library with
+        # workflow batch ID and workflow parameters for that sample
+        mockbatchid = 'globusgalaxy_2016-12-31_1'
+        annotator = annotation.ProcessedLibraryAnnotator(
+            workflowbatch_id=mockbatchid,
+            params=mockparams,
+            db=mock_db
+        )
+
+        # WHEN the mapped model object is retrieved
+        testobject = annotator.get_processed_library()
+
+        # THEN the model object should have expected fields including
+        # for processed data and parent ID, and should no longer be flagged
+        # as mapped
+        assert (testobject.parent_id == mockid)
+        assert not testobject.is_mapped

--- a/tests/test_dbify.py
+++ b/tests/test_dbify.py
@@ -1,6 +1,4 @@
 import logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 import os
 
 import pytest
@@ -9,517 +7,523 @@ import mongomock
 from bripipetools import model as docs
 from bripipetools import dbify
 
-@pytest.fixture(scope='class')
-def mock_db(request):
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='function')
+def mock_db():
+    # GIVEN a mocked version of the TG3 Mongo database
     logger.info(("[setup] mock database, connect "
                  "to mock Mongo database"))
-    db = mongomock.MongoClient().db
 
-    def fin():
-        logger.info(("[teardown] mock database, disconnect "
-                     "from mock Mongo database"))
-    request.addfinalizer(fin)
-    return db
+    yield mongomock.MongoClient().db
+    logger.debug(("[teardown] mock database, disconnect "
+                  "from mock Mongo database"))
 
 
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestSequencingImporter:
-    @pytest.fixture(scope='class', params=[{'runnum': r} for r in range(1)])
-    def importerdata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a SequencingImporter with mock 'genomics' server path to
-        # flowcell run directory and mock database connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        # projects = rundata['processed']['projects']
-        # projectdata = projects[request.param[1]['projectnum']]
-        # sourcedata = projectdata['qc']['sources'][request.param[0]]
-        # samplefile = sourcedata[request.param[1]['samplenum']]
+class TestFlowcellRunImporter:
+    """
 
-        logger.info("[setup] SequencingImporter test instance "
-                    "for run {}".format(rundata['run_id']))
+    """
+    def test_parse_flowcell_path(self, mock_db):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
+        mock_root = '/mnt/'
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = '{}genomics/Illumina/{}'.format(mock_root, mock_id)
 
-        sequencingimporter = dbify.SequencingImporter(
-            path=rundata['path'],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] SequencingImporter mock instance")
-        request.addfinalizer(fin)
-        return (sequencingimporter, rundata)
-
-    def test_parse_flowcell_path(self, importerdata, mock_genomics_server):
-        # (GIVEN)
-        importer, rundata = importerdata
-
-        logger.info("test `_get_genomics_root()`")
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=mock_path,
+            db=mock_db
+        )
 
         # WHEN the path argument is parsed to find the 'genomics' root
         # and flowcell run ID
-        path_items = importer._parse_flowcell_path()
+        test_items = importer._parse_flowcell_path()
 
         # THEN the 'genomics' root and run ID should match the mock server
-        assert(path_items['genomics_root']
-               == mock_genomics_server['root']['path'])
-        assert(path_items['run_id'] == rundata['run_id'])
+        assert (test_items['genomics_root'] == mock_root)
+        assert (test_items['run_id'] == mock_id)
 
-    def test_collect_flowcellrun(self, importerdata):
-        # (GIVEN)
-        importer, _ = importerdata
+    def test_collect_flowcellrun(self, mock_db):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist (note: behavior of of the associated
+        # FlowcellRunAnnotator class when collecting data about a new or
+        # previously imported flowcell run is assumed to be tested in the
+        # `test_annotation` module)
+        mock_root = '/mnt/'
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = '{}genomics/Illumina/{}'.format(mock_root, mock_id)
 
-        logger.info("test `_collect_flowcellrun()`")
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=mock_path,
+            db=mock_db
+        )
 
-        # WHEN collecting FlowcellRun object for flowcell run
-        flowcellrun = importer._collect_flowcellrun()
+        # WHEN collecting model object for flowcell run
+        test_object = importer._collect_flowcellrun()
 
         # THEN should return object of correct type
-        assert(type(flowcellrun) == docs.FlowcellRun)
+        assert (type(test_object) == docs.FlowcellRun)
 
-    def test_collect_sequencedlibraries(self, importerdata):
-        # (GIVEN)
-        importer, rundata = importerdata
+    def test_collect_sequenced_libraries(self, mock_db, tmpdir):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
 
-        logger.info("test `_collect_sequencedlibraries()`")
+        # AND an unaligned folder, which includes multiple project folders,
+        # each with multiple folders for sequenced libraries
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_libs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+                     1: ['lib3333-33333333', 'lib4444-44444444']}
+        unalignedpath = mock_path.mkdir('Unaligned')
+        for idx, p in enumerate(mock_projects):
+            projpath = unalignedpath.mkdir(p)
+            for l in mock_libs[idx]:
+                projpath.mkdir(l)
 
-        # WHEN collecting list of SequencedLibrary objects for flowcell run
-        sequencedlibraries = importer._collect_sequencedlibraries()
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=str(mock_path),
+            db=mock_db
+        )
 
-        # THEN should return 31 total objects of correct type
-        assert(len(sequencedlibraries)
-               == sum(map(lambda x: len(x['samples']),
-                      rundata['unaligned']['projects'])))
-        assert(all([type(sl) == docs.SequencedLibrary
-                    for sl in sequencedlibraries]))
+        # WHEN collecting model objects for sequenced libraries
+        test_objects = importer._collect_sequencedlibraries()
 
-    def test_insert_flowcellrun(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, rundata = importerdata
+        # THEN should return object of correct type
+        assert (all(type(sl) == docs.SequencedLibrary for sl in test_objects))
 
-        logger.info("test `_insert_flowcellrun()`")
+    def test_insert_flowcellrun(self, mock_db):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist (note: behavior for inserting or updating
+        # documents in the database is assumed to be tested in the
+        # `test_genlims` module)
+        mock_root = '/mnt/'
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = '{}genomics/Illumina/{}'.format(mock_root, mock_id)
+
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=mock_path,
+            db=mock_db
+        )
 
         # WHEN flowcell run is inserted into database
         importer._insert_flowcellrun()
 
-        # THEN documents should be present in the runs collection
-        assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-               == 1)
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.runs.drop()
+        # THEN document should be present in the runs collection
+        assert (len(list(mock_db.runs.find({'type': 'flowcell'}))) == 1)
 
-    def test_insert_sequencedlibraries(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, rundata = importerdata
+    def test_insert_sequencedlibraries(self, mock_db, tmpdir):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
 
-        logger.info("test `_insert_sequencedlibraries()`")
+        # AND an unaligned folder, which includes multiple project folders,
+        # each with multiple folders for sequenced libraries
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_libs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+                     1: ['lib3333-33333333', 'lib4444-44444444']}
+        unalignedpath = mock_path.mkdir('Unaligned')
+        for idx, p in enumerate(mock_projects):
+            projpath = unalignedpath.mkdir(p)
+            for l in mock_libs[idx]:
+                projpath.mkdir(l)
+
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=str(mock_path),
+            db=mock_db
+        )
 
         # WHEN sequenced libraries are inserted into database
         importer._insert_sequencedlibraries()
 
-        # THEN documents should be present in the samples collection
-        assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-               == sum(map(lambda x: len(x['samples']),
-                      rundata['unaligned']['projects'])))
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.samples.drop()
+        # THEN document should be present in the runs collection
+        assert (len(list(mock_db.samples.find({'type': 'sequenced library'})))
+                == 4)
 
-    def test_insert_all(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, rundata = importerdata
+    def test_insert(self, mock_db, tmpdir):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
+        mock_id = '161231_INSTID_0001_AC00000XX'
+        mock_path = tmpdir.mkdir('genomics').mkdir('Illumina').mkdir(mock_id)
 
-        logger.info("test `_insert()` for all collections")
+        # AND an unaligned folder, which includes multiple project folders,
+        # each with multiple folders for sequenced libraries
+        mock_projects = ['P1-1-11111111', 'P99-99-99999999']
+        mock_libs = {0: ['lib1111-11111111', 'lib2222-22222222'],
+                     1: ['lib3333-33333333', 'lib4444-44444444']}
+        unalignedpath = mock_path.mkdir('Unaligned')
+        for idx, p in enumerate(mock_projects):
+            projpath = unalignedpath.mkdir(p)
+            for l in mock_libs[idx]:
+                projpath.mkdir(l)
 
-        # WHEN inserting with collection argument set to 'all' (default)
+        # AND an importer object is created for the path
+        importer = dbify.FlowcellRunImporter(
+            path=str(mock_path),
+            db=mock_db
+        )
+
+        # WHEN all objects are inserted into database
         importer.insert()
 
-        # THEN documents should be present in both runs and samples collections
-        assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-               == sum(map(lambda x: len(x['samples']),
-                      rundata['unaligned']['projects'])))
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.runs.drop()
-        mock_db.samples.drop()
-
-    def test_insert_runs(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, rundata = importerdata
-
-        logger.info("test `_insert()` for runs only")
-
-        # WHEN inserting with collection argument set to 'runs'
-        importer.insert(collection='runs')
-
-        # THEN documents should be present in only runs collections
-        assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-               == 0)
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.runs.drop()
-        mock_db.samples.drop()
-
-    def test_insert_samples(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, rundata = importerdata
-
-        logger.info("test `_insert()` for samples only")
-
-        # WHEN inserting with collection argument set to 'samples'
-        importer.insert(collection='samples')
-
-        # THEN new documents should be present in only runs collections
-        assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-               == 0)
-        assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-               == sum(map(lambda x: len(x['samples']),
-                      rundata['unaligned']['projects'])))
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.runs.drop()
-        mock_db.samples.drop()
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestProcessingImporter:
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'batchnum': b}
-                for r in range(1)
-                for b in range(2)])
-    def importerdata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a ProcessingImporter with mock 'genomics' server path to
-        # workflow batch file and mock database connection
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        batches = rundata['submitted']['batches']
-        batchdata = batches[request.param['batchnum']]
-
-        logger.info("[setup] ProcessingImporter test instance "
-                    "for run {} with workflow batch {}"
-                    .format(rundata['run_id'], batchdata['path']))
-
-        processingimporter = dbify.ProcessingImporter(
-            path=batchdata['path'],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] ProcessingImporter mock instance")
-        request.addfinalizer(fin)
-        return (processingimporter, batchdata)
-
-    def test_parse_batch_file_path(self, importerdata, mock_genomics_server):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_get_genomics_root()`")
-
-        # WHEN the path argument is parsed to find the 'genomics' root
-        # and workflow batch file name
-        path_items = importer._parse_batch_file_path()
-
-        # THEN the 'genomics' root and run ID should match the mock server
-        assert(path_items['genomics_root']
-               == mock_genomics_server['root']['path'])
-        assert(path_items['workflowbatch_filename']
-               == os.path.basename(batchdata['path']))
-
-    def test_collect_workflowbatch(self, importerdata):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_collect_workflowbatch()`")
-
-        # WHEN collecting WorkflowBatch object for processing batch
-        workflowbatch = importer._collect_workflowbatch()
-
-        # THEN should return object of correct type
-        assert(type(workflowbatch) == docs.GalaxyWorkflowBatch)
-
-    def test_collect_processedlibraries(self, importerdata):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_collect_processedlibraries()`")
-
-        # WHEN collecting list of ProcessedLibrary objects for workflow batch
-        processedlibraries = importer._collect_processedlibraries()
-
-        # THEN should return expected number of objects of correct type
-        assert(len(processedlibraries) == batchdata['num_samples'])
-        assert(all([type(pl) == docs.ProcessedLibrary
-                    for pl in processedlibraries]))
-
-    def test_insert_workflowbatch(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_insert_workflowbatch()`")
-
-        # WHEN workflow batch is inserted into database
-        importer._insert_workflowbatch()
-
-        # THEN documents should be present in the workflowbatches collection
-        assert(len(list(mock_db.workflowbatches.find(
-               {'type': 'Galaxy workflow batch'})))
-               == 1)
-        logger.info(("[semi-teardown] mock 'tg3' database, "
-                     "drop workflowbatches collection from mock database"))
-        mock_db.workflowbatches.drop()
-
-    def test_insert_processedlibraries(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_insert_processedlibraries()`")
-
-        # WHEN processed libraries are inserted into database
-        importer._insert_processedlibraries()
-
-        # THEN documents should be present in the samples collection
-        assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-               == batchdata['num_samples'])
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.samples.drop()
-
-    def test_insert_all(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_insert()` for all collections")
-
-        # WHEN inserting with collection argument set to 'all' (default)
-        importer.insert()
-
-        # THEN documents should be present in both workflowbatches and
-        # samples collections
-        assert(len(list(mock_db.workflowbatches.find(
-               {'type': 'Galaxy workflow batch'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-               == batchdata['num_samples'])
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-        mock_db.samples.drop()
-
-    def test_insert_workflowbatches(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_insert()` for workflowbatches only")
-
-        # WHEN inserting with collection argument set to 'workflowbatches'
-        importer.insert(collection='workflowbatches')
-
-        # THEN documents should be present in only workflowbatches collections
-        assert(len(list(mock_db.workflowbatches.find(
-               {'type': 'Galaxy workflow batch'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-               == 0)
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-        mock_db.samples.drop()
-
-    def test_insert_samples(self, importerdata, mock_db):
-        # (GIVEN)
-        importer, batchdata = importerdata
-
-        logger.info("test `_insert()` for samples only")
-
-        # WHEN inserting with collection argument set to 'samples'
-        importer.insert(collection='samples')
-
-        # THEN documents should be present in only runs collections
-        assert(len(list(mock_db.workflowbatches.find(
-               {'type': 'Galaxy workflow batch'})))
-               == 0)
-        assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-               == batchdata['num_samples'])
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-        mock_db.samples.drop()
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestImportManagerWithFlowcellPath:
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'batchnum': b}
-                for r in range(1)
-                for b in range(2)])
-    def managerdata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a ImportManager with mock database connection and path
-        # to a flowcell directory
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        batches = rundata['submitted']['batches']
-        batchdata = batches[request.param['batchnum']]
-
-        logger.info("[setup] ImportManager test instance "
-                    "for run {} and/or workflow batch {}"
-                    .format(rundata['run_id'], batchdata['path']))
-
-        importmanager = dbify.ImportManager(
-            path=rundata['path'],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] ImportManager mock instance")
-        request.addfinalizer(fin)
-        return (importmanager, rundata, batchdata)
-
-    def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
-        # (GIVEN)
-        manager, rundata, _ = managerdata
-
-        logger.info("test `_sniff_path()` for flowcell path")
-
-        # WHEN a flowcell path is checked to determine type
-        path_type = manager._sniff_path(rundata['path'])
-
-        # THEN path type should be 'flowcell_path'
-        assert(path_type == 'flowcell_path')
-
-    def test_sniff_path_workflowbatch_file(self, managerdata,
-                                           mock_genomics_server):
-        # (GIVEN)
-        manager, _, batchdata = managerdata
-
-        logger.info("test `_sniff_path()` for workflow batch file")
-
-        # WHEN a flowcell path is checked to determine type
-        path_type = manager._sniff_path(batchdata['path'])
-
-        # THEN path type should be 'flowcell_path'
-        assert(path_type == 'workflowbatch_file')
-
-    def test_init_importer(self, managerdata):
-        # (GIVEN)
-        manager, _, _ = managerdata
-
-        logger.info("test `_init_importer()`")
-
-        # WHEN importer is selected
-        manager._init_importer()
-        importer = manager.importer
-
-        # THEN should be of type SequencingImporter
-        assert(type(importer) == dbify.SequencingImporter)
-
-    def test_run(self, managerdata, mock_db):
-        # (GIVEN)
-        manager, rundata, _ = managerdata
-
-        logger.info("test `run()`")
-
-        # WHEN using run to execute the importer insert method
-        manager.run()
-
-        # THEN documents should be present in both runs and samples collections
-        assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-               == sum(map(lambda x: len(x['samples']),
-                      rundata['unaligned']['projects'])))
-
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-        mock_db.samples.drop()
-
-
-@pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-class TestImportManagerWithWorkflowBatchFile:
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'batchnum': b}
-                for r in range(1)
-                for b in range(2)])
-    def managerdata(self, request, mock_genomics_server, mock_db):
-        # GIVEN a ImportManager with mock database connection and path
-        # to a flowcell directory
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        batches = rundata['submitted']['batches']
-        batchdata = batches[request.param['batchnum']]
-
-        logger.info("[setup] ImportManager test instance "
-                    "for run {} and/or workflow batch {}"
-                    .format(rundata['run_id'], batchdata['path']))
-
-        importmanager = dbify.ImportManager(
-            path=batchdata['path'],
-            db=mock_db)
-
-        def fin():
-            logger.info("[teardown] ImportManager mock instance")
-        request.addfinalizer(fin)
-        return (importmanager, rundata, batchdata)
-
-    def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
-        # (GIVEN)
-        manager, rundata, _ = managerdata
-
-        logger.info("test `_sniff_path()` for flowcell path")
-
-        # WHEN a flowcell path is checked to determine type
-        path_type = manager._sniff_path(rundata['path'])
-
-        # THEN path type should be 'flowcell_path'
-        assert(path_type == 'flowcell_path')
-
-    def test_sniff_path_workflowbatch_file(self, managerdata,
-                                           mock_genomics_server):
-        # (GIVEN)
-        manager, _, batchdata = managerdata
-
-        logger.info("test `_sniff_path()` for workflow batch file")
-
-        # WHEN a flowcell path is checked to determine type
-        path_type = manager._sniff_path(batchdata['path'])
-
-        # THEN path type should be 'flowcell_path'
-        assert(path_type == 'workflowbatch_file')
-
-    def test_init_importer(self, managerdata):
-        # (GIVEN)
-        manager, _, _ = managerdata
-
-        logger.info("test `_init_importer()`")
-
-        # WHEN importer is selected
-        manager._init_importer()
-        importer = manager.importer
-
-        # THEN should be of type SequencingImporter
-        assert(type(importer) == dbify.ProcessingImporter)
-
-    def test_run(self, managerdata, mock_db):
-        # (GIVEN)
-        manager, _, batchdata = managerdata
-
-        logger.info("test `run()`")
-
-        # WHEN using run to execute the importer insert method
-        manager.run()
-
-        # THEN documents should be present in both workflowbatches and
-        # samples collections
-        assert(len(list(mock_db.workflowbatches.find(
-               {'type': 'Galaxy workflow batch'})))
-               == 1)
-        assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-               == batchdata['num_samples'])
-
-        logger.info("[rollback] remove most recently inserted "
-                    "from mock database")
-        mock_db.workflowbatches.drop()
-        mock_db.samples.drop()
+        # THEN documents should be present in the runs collection
+        assert (len(list(mock_db.runs.find({'type': 'flowcell'}))) == 1)
+        assert (len(list(mock_db.samples.find({'type': 'sequenced library'})))
+                == 4)
+
+
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestProcessingImporter:
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'batchnum': b}
+#                 for r in range(1)
+#                 for b in range(2)])
+#     def importerdata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a ProcessingImporter with mock 'genomics' server path to
+#         # workflow batch file and mock database connection
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         batches = rundata['submitted']['batches']
+#         batchdata = batches[request.param['batchnum']]
+#
+#         logger.info("[setup] ProcessingImporter test instance "
+#                     "for run {} with workflow batch {}"
+#                     .format(rundata['run_id'], batchdata['path']))
+#
+#         processingimporter = dbify.ProcessingImporter(
+#             path=batchdata['path'],
+#             db=mock_db)
+#
+#         def fin():
+#             logger.info("[teardown] ProcessingImporter mock instance")
+#         request.addfinalizer(fin)
+#         return (processingimporter, batchdata)
+#
+#     def test_parse_batch_file_path(self, importerdata, mock_genomics_server):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_get_genomics_root()`")
+#
+#         # WHEN the path argument is parsed to find the 'genomics' root
+#         # and workflow batch file name
+#         path_items = importer._parse_batch_file_path()
+#
+#         # THEN the 'genomics' root and run ID should match the mock server
+#         assert(path_items['genomics_root']
+#                == mock_genomics_server['root']['path'])
+#         assert(path_items['workflowbatch_filename']
+#                == os.path.basename(batchdata['path']))
+#
+#     def test_collect_workflowbatch(self, importerdata):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_collect_workflowbatch()`")
+#
+#         # WHEN collecting WorkflowBatch object for processing batch
+#         workflowbatch = importer._collect_workflowbatch()
+#
+#         # THEN should return object of correct type
+#         assert(type(workflowbatch) == docs.GalaxyWorkflowBatch)
+#
+#     def test_collect_processedlibraries(self, importerdata):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_collect_processedlibraries()`")
+#
+#         # WHEN collecting list of ProcessedLibrary objects for workflow batch
+#         processedlibraries = importer._collect_processedlibraries()
+#
+#         # THEN should return expected number of objects of correct type
+#         assert(len(processedlibraries) == batchdata['num_samples'])
+#         assert(all([type(pl) == docs.ProcessedLibrary
+#                     for pl in processedlibraries]))
+#
+#     def test_insert_workflowbatch(self, importerdata, mock_db):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_insert_workflowbatch()`")
+#
+#         # WHEN workflow batch is inserted into database
+#         importer._insert_workflowbatch()
+#
+#         # THEN documents should be present in the workflowbatches collection
+#         assert(len(list(mock_db.workflowbatches.find(
+#                {'type': 'Galaxy workflow batch'})))
+#                == 1)
+#         logger.info(("[semi-teardown] mock 'tg3' database, "
+#                      "drop workflowbatches collection from mock database"))
+#         mock_db.workflowbatches.drop()
+#
+#     def test_insert_processedlibraries(self, importerdata, mock_db):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_insert_processedlibraries()`")
+#
+#         # WHEN processed libraries are inserted into database
+#         importer._insert_processedlibraries()
+#
+#         # THEN documents should be present in the samples collection
+#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
+#                == batchdata['num_samples'])
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.samples.drop()
+#
+#     def test_insert_all(self, importerdata, mock_db):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_insert()` for all collections")
+#
+#         # WHEN inserting with collection argument set to 'all' (default)
+#         importer.insert()
+#
+#         # THEN documents should be present in both workflowbatches and
+#         # samples collections
+#         assert(len(list(mock_db.workflowbatches.find(
+#                {'type': 'Galaxy workflow batch'})))
+#                == 1)
+#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
+#                == batchdata['num_samples'])
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#         mock_db.samples.drop()
+#
+#     def test_insert_workflowbatches(self, importerdata, mock_db):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_insert()` for workflowbatches only")
+#
+#         # WHEN inserting with collection argument set to 'workflowbatches'
+#         importer.insert(collection='workflowbatches')
+#
+#         # THEN documents should be present in only workflowbatches collections
+#         assert(len(list(mock_db.workflowbatches.find(
+#                {'type': 'Galaxy workflow batch'})))
+#                == 1)
+#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
+#                == 0)
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#         mock_db.samples.drop()
+#
+#     def test_insert_samples(self, importerdata, mock_db):
+#         # (GIVEN)
+#         importer, batchdata = importerdata
+#
+#         logger.info("test `_insert()` for samples only")
+#
+#         # WHEN inserting with collection argument set to 'samples'
+#         importer.insert(collection='samples')
+#
+#         # THEN documents should be present in only runs collections
+#         assert(len(list(mock_db.workflowbatches.find(
+#                {'type': 'Galaxy workflow batch'})))
+#                == 0)
+#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
+#                == batchdata['num_samples'])
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#         mock_db.samples.drop()
+#
+#
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestImportManagerWithFlowcellPath:
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'batchnum': b}
+#                 for r in range(1)
+#                 for b in range(2)])
+#     def managerdata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a ImportManager with mock database connection and path
+#         # to a flowcell directory
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         batches = rundata['submitted']['batches']
+#         batchdata = batches[request.param['batchnum']]
+#
+#         logger.info("[setup] ImportManager test instance "
+#                     "for run {} and/or workflow batch {}"
+#                     .format(rundata['run_id'], batchdata['path']))
+#
+#         importmanager = dbify.ImportManager(
+#             path=rundata['path'],
+#             db=mock_db)
+#
+#         def fin():
+#             logger.info("[teardown] ImportManager mock instance")
+#         request.addfinalizer(fin)
+#         return (importmanager, rundata, batchdata)
+#
+#     def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
+#         # (GIVEN)
+#         manager, rundata, _ = managerdata
+#
+#         logger.info("test `_sniff_path()` for flowcell path")
+#
+#         # WHEN a flowcell path is checked to determine type
+#         path_type = manager._sniff_path(rundata['path'])
+#
+#         # THEN path type should be 'flowcell_path'
+#         assert(path_type == 'flowcell_path')
+#
+#     def test_sniff_path_workflowbatch_file(self, managerdata,
+#                                            mock_genomics_server):
+#         # (GIVEN)
+#         manager, _, batchdata = managerdata
+#
+#         logger.info("test `_sniff_path()` for workflow batch file")
+#
+#         # WHEN a flowcell path is checked to determine type
+#         path_type = manager._sniff_path(batchdata['path'])
+#
+#         # THEN path type should be 'flowcell_path'
+#         assert(path_type == 'workflowbatch_file')
+#
+#     def test_init_importer(self, managerdata):
+#         # (GIVEN)
+#         manager, _, _ = managerdata
+#
+#         logger.info("test `_init_importer()`")
+#
+#         # WHEN importer is selected
+#         manager._init_importer()
+#         importer = manager.importer
+#
+#         # THEN should be of type SequencingImporter
+#         assert(type(importer) == dbify.SequencingImporter)
+#
+#     def test_run(self, managerdata, mock_db):
+#         # (GIVEN)
+#         manager, rundata, _ = managerdata
+#
+#         logger.info("test `run()`")
+#
+#         # WHEN using run to execute the importer insert method
+#         manager.run()
+#
+#         # THEN documents should be present in both runs and samples collections
+#         assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
+#                == 1)
+#         assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
+#                == sum(map(lambda x: len(x['samples']),
+#                       rundata['unaligned']['projects'])))
+#
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#         mock_db.samples.drop()
+#
+#
+# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
+# class TestImportManagerWithWorkflowBatchFile:
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'batchnum': b}
+#                 for r in range(1)
+#                 for b in range(2)])
+#     def managerdata(self, request, mock_genomics_server, mock_db):
+#         # GIVEN a ImportManager with mock database connection and path
+#         # to a flowcell directory
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         batches = rundata['submitted']['batches']
+#         batchdata = batches[request.param['batchnum']]
+#
+#         logger.info("[setup] ImportManager test instance "
+#                     "for run {} and/or workflow batch {}"
+#                     .format(rundata['run_id'], batchdata['path']))
+#
+#         importmanager = dbify.ImportManager(
+#             path=batchdata['path'],
+#             db=mock_db)
+#
+#         def fin():
+#             logger.info("[teardown] ImportManager mock instance")
+#         request.addfinalizer(fin)
+#         return (importmanager, rundata, batchdata)
+#
+#     def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
+#         # (GIVEN)
+#         manager, rundata, _ = managerdata
+#
+#         logger.info("test `_sniff_path()` for flowcell path")
+#
+#         # WHEN a flowcell path is checked to determine type
+#         path_type = manager._sniff_path(rundata['path'])
+#
+#         # THEN path type should be 'flowcell_path'
+#         assert(path_type == 'flowcell_path')
+#
+#     def test_sniff_path_workflowbatch_file(self, managerdata,
+#                                            mock_genomics_server):
+#         # (GIVEN)
+#         manager, _, batchdata = managerdata
+#
+#         logger.info("test `_sniff_path()` for workflow batch file")
+#
+#         # WHEN a flowcell path is checked to determine type
+#         path_type = manager._sniff_path(batchdata['path'])
+#
+#         # THEN path type should be 'flowcell_path'
+#         assert(path_type == 'workflowbatch_file')
+#
+#     def test_init_importer(self, managerdata):
+#         # (GIVEN)
+#         manager, _, _ = managerdata
+#
+#         logger.info("test `_init_importer()`")
+#
+#         # WHEN importer is selected
+#         manager._init_importer()
+#         importer = manager.importer
+#
+#         # THEN should be of type SequencingImporter
+#         assert(type(importer) == dbify.ProcessingImporter)
+#
+#     def test_run(self, managerdata, mock_db):
+#         # (GIVEN)
+#         manager, _, batchdata = managerdata
+#
+#         logger.info("test `run()`")
+#
+#         # WHEN using run to execute the importer insert method
+#         manager.run()
+#
+#         # THEN documents should be present in both workflowbatches and
+#         # samples collections
+#         assert(len(list(mock_db.workflowbatches.find(
+#                {'type': 'Galaxy workflow batch'})))
+#                == 1)
+#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
+#                == batchdata['num_samples'])
+#
+#         logger.info("[rollback] remove most recently inserted "
+#                     "from mock database")
+#         mock_db.workflowbatches.drop()
+#         mock_db.samples.drop()

--- a/tests/test_dbify.py
+++ b/tests/test_dbify.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import pytest
 import mongomock
@@ -24,7 +23,8 @@ def mock_db():
 
 class TestFlowcellRunImporter:
     """
-
+    Tests methods for the `FlowcellRunImporter` class in the
+    `bripipetools.dbify.flowcellrun` module.
     """
     def test_parse_flowcell_path(self, mock_db):
         # GIVEN a path to a flowcell run folder and a connection to a
@@ -181,7 +181,7 @@ class TestFlowcellRunImporter:
         # WHEN all objects are inserted into database
         importer.insert()
 
-        # THEN documents should be present in the runs collection
+        # THEN documents should be present in the runs and samples collections
         assert (len(list(mock_db.runs.find({'type': 'flowcell'}))) == 1)
         assert (len(list(mock_db.samples.find({'type': 'sequenced library'})))
                 == 4)
@@ -189,6 +189,7 @@ class TestFlowcellRunImporter:
 
 @pytest.fixture(scope='function')
 def mock_batchfile(filename, tmpdir):
+    # GIVEN a simplified workflow batch content with protypical contents
     mock_contents = ['###METADATA\n',
                      '#############\n',
                      'Workflow Name\toptimized_workflow_1\n',
@@ -205,16 +206,16 @@ def mock_batchfile(filename, tmpdir):
 
 class TestWorkflowBatchImporter:
     """
-
+    Tests methods for the `WorkflowBatchImporter` class in the
+    `bripipetools.dbify.workflowbatch` module.
     """
     def test_parse_batch_file_path(self, mock_db, tmpdir):
-        # GIVEN a path to a flowcell run folder and a connection to a
-        # database in which a document corresponding to the flowcell run
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
         # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
-
         mock_filename = '161231_P00-00_C00000XX_workflow-name.txt'
         mock_path = mock_batchfile(mock_filename, mock_path)
 
@@ -233,6 +234,12 @@ class TestWorkflowBatchImporter:
         assert (test_items['workflowbatch_filename'] == mock_filename)
 
     def test_collect_workflowbatch(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist (note: behavior of of the associated
+        # WorkflowBatchAnnotator class when collecting data about a new or
+        # previously imported workflow batch is assumed to be tested in the
+        # `test_annotation` module)
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
@@ -246,17 +253,19 @@ class TestWorkflowBatchImporter:
             db=mock_db
         )
 
-        # WHEN collecting model object for flowcell run
+        # WHEN collecting model object for workflow batch
         test_object = importer._collect_workflowbatch()
 
         # THEN should return object of correct type
         assert (type(test_object) == docs.GalaxyWorkflowBatch)
 
     def test_collect_processedlibraries(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
-
         mock_filename = '161231_P1-1_P99-99_C00000XX_workflow-name.txt'
         mock_path = mock_batchfile(mock_filename, mock_path)
 
@@ -266,17 +275,22 @@ class TestWorkflowBatchImporter:
             db=mock_db
         )
 
-        # WHEN collecting model object for flowcell run
+        # WHEN collecting model objects for processed libraries
+        # from the workflow batch
         test_objects = importer._collect_processedlibraries()
 
-        # THEN should return object of correct type
+        # THEN should return objects of correct type
         assert (all(type(pl) == docs.ProcessedLibrary for pl in test_objects))
 
     def test_insert_workflowbatch(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist (note: behavior for inserting or updating
+        # documents in the database is assumed to be tested in the
+        # `test_genlims` module)
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
-
         mock_filename = '161231_P1-1_P99-99_C00000XX_workflow-name.txt'
         mock_path = mock_batchfile(mock_filename, mock_path)
 
@@ -295,10 +309,12 @@ class TestWorkflowBatchImporter:
                 == 1)
 
     def test_insert_processedlibraries(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
-
         mock_filename = '161231_P1-1_P99-99_C00000XX_workflow-name.txt'
         mock_path = mock_batchfile(mock_filename, mock_path)
 
@@ -308,14 +324,17 @@ class TestWorkflowBatchImporter:
             db=mock_db
         )
 
-        # WHEN flowcell run is inserted into database
+        # WHEN processed libraries inserted into database
         importer._insert_processedlibraries()
 
-        # THEN document should be present in the runs collection
+        # THEN documents should be present in the samples collection
         assert (len(list(mock_db.samples.find({'type': 'processed library'})))
                 == 2)
 
     def test_insert(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
@@ -332,7 +351,8 @@ class TestWorkflowBatchImporter:
         # WHEN all objects are inserted into database
         importer.insert()
 
-        # THEN documents should be present in the runs collection
+        # THEN documents should be present in the workflowbatches
+        # and samples collections
         assert (len(list(mock_db.workflowbatches
                          .find({'type': 'Galaxy workflow batch'})))
                 == 1)
@@ -342,13 +362,17 @@ class TestWorkflowBatchImporter:
 
 class TestImportManager:
     """
-
+    Tests methods for the `ImportManager` class in the
+    `bripipetools.dbify.control` module.
     """
-
     def test_sniff_path_for_flowcell_run(self, mock_db):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = '/mnt/genomics/Illumina/{}'.format(mock_id)
 
+        # AND an import manager is created for the path
         manager = dbify.ImportManager(
             path=mock_path,
             db=mock_db
@@ -361,11 +385,15 @@ class TestImportManager:
         assert (test_type == 'flowcell_path')
 
     def test_sniff_path_for_workflow_batch(self, mock_db):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_filename = '161231_P1-1_P99-99_C00000XX_workflow-name.txt'
         mock_path = ('/mnt/genomics/Illumina/{}/globus_batch_submission/{}'
                      .format(mock_id, mock_filename))
 
+        # AND an import manager is created for the path
         manager = dbify.ImportManager(
             path=mock_path,
             db=mock_db
@@ -374,10 +402,13 @@ class TestImportManager:
         # WHEN path is checked to determine type
         test_type = manager._sniff_path()
 
-        # THEN path type should be 'flowcell_path'
+        # THEN path type should be 'workflowbatch_file'
         assert (test_type == 'workflowbatch_file')
 
     def test_init_importer_for_flowcell_run(self, mock_db):
+        # GIVEN a path to a flowcell run folder and a connection to a
+        # database in which a document corresponding to the flowcell run
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = '/mnt/genomics/Illumina/{}'.format(mock_id)
 
@@ -386,13 +417,16 @@ class TestImportManager:
             db=mock_db
         )
 
-        # WHEN path is checked to determine type
+        # AND an import manager is created for the path
         manager._init_importer()
 
-        # THEN path type should be 'flowcell_path'
+        # THEN importer should be correct type
         assert (type(manager.importer) == dbify.FlowcellRunImporter)
 
     def test_init_importer_for_workflow_batch(self, mock_db):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_filename = '161231_P1-1_P99-99_C00000XX_workflow-name.txt'
         mock_path = ('/mnt/genomics/Illumina/{}/globus_batch_submission/{}'
@@ -403,10 +437,10 @@ class TestImportManager:
             db=mock_db
         )
 
-        # WHEN path is checked to determine type
+        # WHEN importer object is initialized
         manager._init_importer()
 
-        # THEN path type should be 'flowcell_path'
+        # THEN importer should be correct type
         assert (type(manager.importer) == dbify.WorkflowBatchImporter)
 
     def test_run_for_flowcell_run(self, mock_db, tmpdir):
@@ -427,7 +461,7 @@ class TestImportManager:
             for l in mock_libs[idx]:
                 projpath.mkdir(l)
 
-        # AND an importer object is created for the path
+        # AND an import manager is created for the path
         manager = dbify.ImportManager(
             path=str(mock_path),
             db=mock_db
@@ -436,12 +470,15 @@ class TestImportManager:
         # WHEN all objects are inserted into database
         manager.run()
 
-        # THEN documents should be present in the runs collection
+        # THEN documents should be present in the runs and samples collections
         assert (len(list(mock_db.runs.find({'type': 'flowcell'}))) == 1)
         assert (len(list(mock_db.samples.find({'type': 'sequenced library'})))
                 == 4)
 
     def test_run_for_workflow_batch(self, mock_db, tmpdir):
+        # GIVEN a path to a workflow batch file and a connection to a
+        # database in which a document corresponding to the workflow batch
+        # may or may not exist
         mock_id = '161231_INSTID_0001_AC00000XX'
         mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
                      .mkdir(mock_id).mkdir('globus_batch_submission'))
@@ -458,185 +495,10 @@ class TestImportManager:
         # WHEN all objects are inserted into database
         manager.run()
 
-        # THEN documents should be present in the runs collection
+        # THEN documents should be present in the workflowbatches and
+        # samples collections
         assert (len(list(mock_db.workflowbatches
                          .find({'type': 'Galaxy workflow batch'})))
                 == 1)
         assert (len(list(mock_db.samples.find({'type': 'processed library'})))
                 == 2)
-
-# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-# class TestImportManagerWithFlowcellPath:
-#     @pytest.fixture(
-#         scope='class',
-#         params=[{'runnum': r, 'batchnum': b}
-#                 for r in range(1)
-#                 for b in range(2)])
-#     def managerdata(self, request, mock_genomics_server, mock_db):
-#         # GIVEN a ImportManager with mock database connection and path
-#         # to a flowcell directory
-#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-#         rundata = runs[request.param['runnum']]
-#         batches = rundata['submitted']['batches']
-#         batchdata = batches[request.param['batchnum']]
-#
-#         logger.info("[setup] ImportManager test instance "
-#                     "for run {} and/or workflow batch {}"
-#                     .format(rundata['run_id'], batchdata['path']))
-#
-#         importmanager = dbify.ImportManager(
-#             path=rundata['path'],
-#             db=mock_db)
-#
-#         def fin():
-#             logger.info("[teardown] ImportManager mock instance")
-#         request.addfinalizer(fin)
-#         return (importmanager, rundata, batchdata)
-#
-#     def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
-#         # (GIVEN)
-#         manager, rundata, _ = managerdata
-#
-#         logger.info("test `_sniff_path()` for flowcell path")
-#
-#         # WHEN a flowcell path is checked to determine type
-#         path_type = manager._sniff_path(rundata['path'])
-#
-#         # THEN path type should be 'flowcell_path'
-#         assert(path_type == 'flowcell_path')
-#
-#     def test_sniff_path_workflowbatch_file(self, managerdata,
-#                                            mock_genomics_server):
-#         # (GIVEN)
-#         manager, _, batchdata = managerdata
-#
-#         logger.info("test `_sniff_path()` for workflow batch file")
-#
-#         # WHEN a flowcell path is checked to determine type
-#         path_type = manager._sniff_path(batchdata['path'])
-#
-#         # THEN path type should be 'flowcell_path'
-#         assert(path_type == 'workflowbatch_file')
-#
-#     def test_init_importer(self, managerdata):
-#         # (GIVEN)
-#         manager, _, _ = managerdata
-#
-#         logger.info("test `_init_importer()`")
-#
-#         # WHEN importer is selected
-#         manager._init_importer()
-#         importer = manager.importer
-#
-#         # THEN should be of type SequencingImporter
-#         assert(type(importer) == dbify.SequencingImporter)
-#
-#     def test_run(self, managerdata, mock_db):
-#         # (GIVEN)
-#         manager, rundata, _ = managerdata
-#
-#         logger.info("test `run()`")
-#
-#         # WHEN using run to execute the importer insert method
-#         manager.run()
-#
-#         # THEN documents should be present in both runs and samples collections
-#         assert(len(list(mock_db.runs.find({'type': 'flowcell'})))
-#                == 1)
-#         assert(len(list(mock_db.samples.find({'type': 'sequenced library'})))
-#                == sum(map(lambda x: len(x['samples']),
-#                       rundata['unaligned']['projects'])))
-#
-#         logger.info("[rollback] remove most recently inserted "
-#                     "from mock database")
-#         mock_db.workflowbatches.drop()
-#         mock_db.samples.drop()
-#
-#
-# @pytest.mark.usefixtures('mock_genomics_server', 'mock_db')
-# class TestImportManagerWithWorkflowBatchFile:
-#     @pytest.fixture(
-#         scope='class',
-#         params=[{'runnum': r, 'batchnum': b}
-#                 for r in range(1)
-#                 for b in range(2)])
-#     def managerdata(self, request, mock_genomics_server, mock_db):
-#         # GIVEN a ImportManager with mock database connection and path
-#         # to a flowcell directory
-#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-#         rundata = runs[request.param['runnum']]
-#         batches = rundata['submitted']['batches']
-#         batchdata = batches[request.param['batchnum']]
-#
-#         logger.info("[setup] ImportManager test instance "
-#                     "for run {} and/or workflow batch {}"
-#                     .format(rundata['run_id'], batchdata['path']))
-#
-#         importmanager = dbify.ImportManager(
-#             path=batchdata['path'],
-#             db=mock_db)
-#
-#         def fin():
-#             logger.info("[teardown] ImportManager mock instance")
-#         request.addfinalizer(fin)
-#         return (importmanager, rundata, batchdata)
-#
-#     def test_sniff_path_flowcell_path(self, managerdata, mock_genomics_server):
-#         # (GIVEN)
-#         manager, rundata, _ = managerdata
-#
-#         logger.info("test `_sniff_path()` for flowcell path")
-#
-#         # WHEN a flowcell path is checked to determine type
-#         path_type = manager._sniff_path(rundata['path'])
-#
-#         # THEN path type should be 'flowcell_path'
-#         assert(path_type == 'flowcell_path')
-#
-#     def test_sniff_path_workflowbatch_file(self, managerdata,
-#                                            mock_genomics_server):
-#         # (GIVEN)
-#         manager, _, batchdata = managerdata
-#
-#         logger.info("test `_sniff_path()` for workflow batch file")
-#
-#         # WHEN a flowcell path is checked to determine type
-#         path_type = manager._sniff_path(batchdata['path'])
-#
-#         # THEN path type should be 'flowcell_path'
-#         assert(path_type == 'workflowbatch_file')
-#
-#     def test_init_importer(self, managerdata):
-#         # (GIVEN)
-#         manager, _, _ = managerdata
-#
-#         logger.info("test `_init_importer()`")
-#
-#         # WHEN importer is selected
-#         manager._init_importer()
-#         importer = manager.importer
-#
-#         # THEN should be of type SequencingImporter
-#         assert(type(importer) == dbify.ProcessingImporter)
-#
-#     def test_run(self, managerdata, mock_db):
-#         # (GIVEN)
-#         manager, _, batchdata = managerdata
-#
-#         logger.info("test `run()`")
-#
-#         # WHEN using run to execute the importer insert method
-#         manager.run()
-#
-#         # THEN documents should be present in both workflowbatches and
-#         # samples collections
-#         assert(len(list(mock_db.workflowbatches.find(
-#                {'type': 'Galaxy workflow batch'})))
-#                == 1)
-#         assert(len(list(mock_db.samples.find({'type': 'processed library'})))
-#                == batchdata['num_samples'])
-#
-#         logger.info("[rollback] remove most recently inserted "
-#                     "from mock database")
-#         mock_db.workflowbatches.drop()
-#         mock_db.samples.drop()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -154,3 +154,38 @@ class TestIllumina:
         assert(batch_items['date'] == datetime.datetime(2016, 9, 29, 0, 0))
         assert(batch_items['projects'] == ['P109-1', 'P14-12'])
         assert(batch_items['flowcell_id'] == 'C6VG0ANXX')
+
+#
+#     def test_parse_output_name_onepart_source(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_parse_output_name()`, one-part source")
+#
+#         # WHEN parsing output name from workflow batch parameter, and the
+#         # source name has one parts (i.e., 'tophat')
+#         output_items = annotator._parse_output_name(
+#             'tophat_alignments_bam_out')
+#
+#         # THEN output items should be a dictionary including fields for
+#         # name, type, and source
+#         assert(output_items['name'] == 'tophat_alignments_bam')
+#         assert(output_items['type'] == 'alignments')
+#         assert(output_items['source'] == 'tophat')
+#
+#     def test_parse_output_name_twopart_source(self, annotatordata):
+#         # (GIVEN)
+#         annotator, _, _ = annotatordata
+#
+#         logger.info("test `_parse_output_name()`, two-part source")
+#
+#         # WHEN parsing output name from workflow batch parameter, and the
+#         # source name has two parts (i.e., 'picard_rnaseq')
+#         output_items = annotator._parse_output_name(
+#             'picard_rnaseq_metrics_html_out')
+#
+#         # THEN output items should be a dictionary including fields for
+#         # name, type, and source
+#         assert(output_items['name'] == 'picard_rnaseq_metrics_html')
+#         assert(output_items['type'] == 'metrics')
+#         assert(output_items['source'] == 'picard_rnaseq')

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from bripipetools import parsing
@@ -140,3 +142,15 @@ class TestIllumina:
         assert (fastq_items['lane_id'] == 'L001')
         assert (fastq_items['read_id'] == 'R1')
         assert (fastq_items['sample_number'] == 1)
+
+    def test_parse_batch_name(self):
+        # GIVEN any state
+
+        # WHEN parsing batch name from workflow batch file
+        batch_items = parsing.parse_batch_name('160929_P109-1_P14-12_C6VG0ANXX')
+
+        # THEN items should be in a dict with fields for date (string),
+        # project labels (list of strings), and flowcell ID (string)
+        assert(batch_items['date'] == datetime.datetime(2016, 9, 29, 0, 0))
+        assert(batch_items['projects'] == ['P109-1', 'P14-12'])
+        assert(batch_items['flowcell_id'] == 'C6VG0ANXX')

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -638,7 +638,6 @@ class TestOutputCleaner:
         mock_subdir = mock_path.mkdir('subfolder')
         mock_zipdir = mock_subdir.mkdir('zipfolder')
         mock_zipdir.ensure('outfile1')
-        logger.debug("mock zipfolder contents: {}".format(mock_zipdir.listdir()))
 
         mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
                                            str(mock_zipdir))

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -638,7 +638,7 @@ class TestOutputCleaner:
         mock_zipdir = mock_subdir.mkdir('zipfolder')
         mock_zipdir.ensure('outfile1')
         mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
-                                          str(mock_zipdir))
+                                           str(mock_zipdir))
         shutil.rmtree(str(mock_zipdir))
 
         # AND a cleaner object is created for the path
@@ -653,7 +653,8 @@ class TestOutputCleaner:
         # individual output files exist directly under the subfolder,
         # and these files should then be unnested and exist directly
         # under the output type folder (labeled as '<subfolder>_<filename>'
-        assert('subfolder_outfile1' in str(mock_path.listdir()))
+        assert ('subfolder_outfile1' in
+                [os.path.basename(str(f)) for f in mock_path.listdir()])
 
     def test_recode_output(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
@@ -671,7 +672,8 @@ class TestOutputCleaner:
 
         # THEN the new filename should match the expected result
         assert (os.path.basename(testpath) == 'libID_fcID_fastqc_qc.txt')
-        assert ('libID_fcID_fastqc_qc.txt' in str(mock_path.listdir()))
+        assert ('libID_fcID_fastqc_qc.txt' in
+                [os.path.basename(str(f)) for f in mock_path.listdir()])
 
     def test_clean_outputs(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
@@ -702,5 +704,5 @@ class TestOutputCleaner:
 
         # THEN the updated output organization should match expected results
         assert (len(mock_path.listdir()) == 4)
-        assert ('lib1111_C00000XX_fastqc_qc.txt'
-                in str(mock_path.listdir()))
+        assert ('lib1111_C00000XX_fastqc_qc.txt' in
+                [os.path.basename(str(f)) for f in mock_path.listdir()])

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -587,7 +587,6 @@ class TestOutputCleaner:
         # output files
         mock_zipdir = mock_path.mkdir('zipfolder')
         mock_zipdir.ensure('outfile1')
-        logger.debug("mock zipfolder contents: {}".format(mock_zipdir.listdir()))
         mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
                                            str(mock_zipdir))
         shutil.rmtree(str(mock_zipdir))
@@ -639,6 +638,8 @@ class TestOutputCleaner:
         mock_subdir = mock_path.mkdir('subfolder')
         mock_zipdir = mock_subdir.mkdir('zipfolder')
         mock_zipdir.ensure('outfile1')
+        logger.debug("mock zipfolder contents: {}".format(mock_zipdir.listdir()))
+
         mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
                                            str(mock_zipdir))
         shutil.rmtree(str(mock_zipdir))

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -587,8 +587,9 @@ class TestOutputCleaner:
         # output files
         mock_zipdir = mock_path.mkdir('zipfolder')
         mock_zipdir.ensure('outfile1')
+        logger.debug("mock zipfolder contents: {}".format(mock_zipdir.listdir()))
         mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
-                                          str(mock_zipdir))
+                                           str(mock_zipdir))
         shutil.rmtree(str(mock_zipdir))
 
         # AND a cleaner object is created for the path

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -6,377 +6,470 @@ import re
 import shutil
 
 import pytest
+import pandas as pd
 
 from bripipetools import postprocess
 from bripipetools import io
 
-@pytest.mark.usefixtures('mock_genomics_server')
+
 class TestOutputStitcher:
-    @pytest.fixture(
-        scope='class',
-        params=[(out_type, {'runnum': r, 'projectnum': p})
-                for r in range(1)
-                for p in range(3)
-                for out_type in ['metrics', 'qc', 'counts', 'validation']])
-    def outputstitcherdata(self, request, mock_genomics_server):
-        # GIVEN a OutputStitcher with mock 'genomics' server path to outputs
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param[1]['runnum']]
-        projects = rundata['processed']['projects']
-        projectdata = projects[request.param[1]['projectnum']]
-        outputdata = projectdata[request.param[0]]
-
-        logger.info("[setup] OutputStitcher test instance "
-                    "for output type '{}'".format(request.param))
-
-        outputstitcher = postprocess.OutputStitcher(
-            path=outputdata['path'])
-
-        def fin():
-            logger.info("[teardown] OutputStitcher mock instance")
-        request.addfinalizer(fin)
-        return (outputstitcher, outputdata, request.param[0])
-
-    def test_sniff_output_type(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, _, out_type = outputstitcherdata
-
-        logger.info("test `_sniff_output_type()`")
-
-        # WHEN the file specified by path is read
-        output_type = outputstitcher._sniff_output_type()
-
-        # THEN output type should match expected type
-        assert(output_type == out_type)
-
-    def test_get_outputs(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, _ = outputstitcherdata
-
-        logger.info("test `_get_outputs()`")
-
-        # WHEN the list of output files is collected
-        outputs = outputstitcher._get_outputs(outputstitcher.type)
-
-        # THEN the expected number of outputs should be found
-        assert(len(outputs)
-               == sum(map(lambda x: len(x),
-                      outputdata['sources'].values())))
 
     @pytest.mark.parametrize(
-        'output,expected',
-        [(('metrics', 'htseq'), getattr(io, 'HtseqMetricsFile')),
-         (('metrics', 'picard_rnaseq'), getattr(io, 'PicardMetricsFile')),
-         (('metrics', 'picard_markdups'), getattr(io, 'PicardMetricsFile')),
-         (('metrics', 'picard_align'), getattr(io, 'PicardMetricsFile')),
-         (('metrics', 'tophat_stats'), getattr(io, 'TophatStatsFile')),
-         (('qc', 'fastqc'), getattr(io, 'FastQCFile')),
-         (('counts', 'htseq'), getattr(io, 'HtseqCountsFile')),
-         (('validation', 'sexcheck'), getattr(io, 'SexcheckFile'))])
-    def test_get_parser(self, outputstitcherdata, output, expected):
-        # (GIVEN)
-        outputstitcher, _, _ = outputstitcherdata
+        'test_input, expected_result',
+        [
+            ('counts', 'counts'),
+            ('metrics', 'metrics'),
+            ('QC', 'qc'),
+            ('validation', 'validation'),
+        ]
+    )
+    def test_sniff_output_type(self, tmpdir, test_input, expected_result):
+        mockpath = tmpdir.join(test_input)
 
-        logger.info("test `_get_parser()`")
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        assert (stitcher._sniff_output_type() == expected_result)
+
+    @pytest.mark.parametrize(
+        'test_input, expected_result',
+        [
+            (('metrics', 'htseq'), getattr(io, 'HtseqMetricsFile')),
+            (('metrics', 'picard_rnaseq'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'picard_markdups'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'picard_align'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'tophat_stats'), getattr(io, 'TophatStatsFile')),
+            (('qc', 'fastqc'), getattr(io, 'FastQCFile')),
+            (('counts', 'htseq'), getattr(io, 'HtseqCountsFile')),
+            (('validation', 'sexcheck'), getattr(io, 'SexcheckFile'))
+        ]
+    )
+    def test_get_parser(self, tmpdir, test_input, expected_result):
+        mockpath = tmpdir.join('')
+
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        mocktype, mocksource = test_input
 
         # WHEN the parser is retrieved given output type and source
-        parser = outputstitcher._get_parser(output[0], output[1])
+        testparser = stitcher._get_parser(mocktype, mocksource)
 
         # THEN the expected number of outputs should be found
-        assert(parser == expected)
-
-    def test_read_data(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        logger.info("test `_read_data()`")
-
-        # WHEN data from each output file is read and parsed
-        outputstitcher._read_data()
-        data = outputstitcher.data[out_type]
-
-        # THEN data should be stored in a dictionary named for the current
-        # output type, with a sub-dict for each output source
-        assert(all([len(data[s]) == len(outputdata['sources'])
-                    for s in data]))
-
-    def test_build_table(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        logger.info("test `_build_table()`")
-
-        # WHEN data is combined into a table
-        outputstitcher._read_data()
-        table_data = outputstitcher._build_table()
-
-        # THEN table should have expected number of rows, and rows should
-        # be the same length
-        assert(len(table_data) == outputdata['combined']['len_table'])
-
-    def test_build_combined_filename(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        logger.info("test `_build_combined_filename()`")
-
-        # WHEN path to outputs is parsed to build combined CSV file_name
-        combined_filename = outputstitcher._build_combined_filename()
-
-        # THEN combined filename should be correctly formatted
-        output_type = outputstitcher.type
-        assert(combined_filename
-               == os.path.basename(outputdata['combined']['path']))
-
-    def test_build_overrepresented_seq_table(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        # WHEN overrepresented sequences are combined into a table
-        overrep_seq_table = outputstitcher._build_overrepresented_seq_table()
-
-        if out_type == 'qc':
-            assert(len(overrep_seq_table)
-                   == sum(map(lambda x: x['num_overrep_seqs'],
-                          outputdata['sources']['fastqc'])))
-        else:
-            assert(len(overrep_seq_table) == 0)
-
-    def test_write_overrepresented_seq_table(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        # AND combined overrepresented seqs file does not already exist
-        if out_type == 'qc':
-            expected_path = outputdata['combined_overrep_seqs']['path']
-            try:
-                os.remove(expected_path)
-            except OSError:
-                pass
-
-            # WHEN data is read and combined overrepresented seqs are written
-            # to file
-            outputstitcher.write_overrepresented_seq_table()
-
-            # THEN file should exist at expected path
-            assert(os.path.exists(expected_path))
-
-    def test_write_table(self, outputstitcherdata):
-        # (GIVEN)
-        outputstitcher, outputdata, out_type = outputstitcherdata
-
-        logger.info("test `write_table()`")
-
-        # AND combined file does not already exist
-        expected_path = outputdata['combined']['path']
-        try:
-            os.remove(expected_path)
-        except OSError:
-            pass
-
-        # WHEN data is read, combined, and written to file
-        outputstitcher.write_table()
-
-        # THEN file should exist at expected path
-        assert(os.path.exists(expected_path))
-
-
-class TestOutputCompiler:
-    @pytest.fixture(
-        scope='class',
-        params=[{'runnum': r, 'projectnum': p}
-                for r in range(1)
-                for p in range(3)])
-    def compilerdata(self, request, mock_genomics_server):
-        # GIVEN a OutputCompiler with list of mock 'genomics' server path to
-        # combined output files
-        runs = mock_genomics_server['root']['genomics']['illumina']['runs']
-        rundata = runs[request.param['runnum']]
-        projects = rundata['processed']['projects']
-        projectdata = projects[request.param['projectnum']]
-        outputs = [projectdata[out_type]['combined']
-                   for out_type in projectdata
-                   if out_type not in ['path', 'counts', 'combined_summary']]
-        outputdata = projectdata['combined_summary']
-
-        logger.info("[setup] OutputCompiler test instance "
-                    "for combined output files '{}'"
-                    .format([f['path'] for f in outputs]))
-
-        outputcompiler = postprocess.OutputCompiler(
-            paths=[f['path'] for f in outputs])
-
-        def fin():
-            logger.info("[teardown] OutputCompiler mock instance")
-        request.addfinalizer(fin)
-        return (outputcompiler, outputs, outputdata)
-
-    def test_init(self, compilerdata):
-        # (GIVEN)
-        outputcompiler, outputs, _ = compilerdata
-
-        logger.info("test `__init__()`")
-
-        # WHEN object is created
-
-        # THEN should have expected paths stored as attribute
-        assert(len(outputcompiler.paths) == len(outputs))
-
-    def test_read_data(self, compilerdata):
-        # (GIVEN)
-        outputcompiler, outputs, _ = compilerdata
-
-        logger.info("test `_read_data()`")
-
-        # WHEN data from individual file paths are read into a list
-        outputcompiler._read_data()
-
-        # THEN data should be stored as list of expected length
-        assert(len(outputcompiler.data) == len(outputs))
-
-    def test_build_table(self, compilerdata):
-        # (GIVEN)
-        outputcompiler, outputs, _ = compilerdata
-
-        logger.info("test `_build_table()`")
-
-        # WHEN data are combined into a single table
-        table_data = outputcompiler._build_table()
-
-        # THEN the table should have the same number of rows (list elements)
-        # as the first combined output table in the list; and 'libId' should
-        # only appear once in the header row
-        assert(len(table_data) == outputs[0]['len_table'])
-        assert(table_data[0].count('libId') == 1)
-
-    def test_build_combined_filename(self, compilerdata):
-        # (GIVEN)
-        outputcompiler, outputs, outputdata = compilerdata
-
-        logger.info("test `_build_combined_filename()`")
-
-        # WHEN path to outputs is parsed to build combined CSV file name
-        combined_filename = outputcompiler._build_combined_filename()
-
-        # THEN combined filename should be correctly formatted
-        assert(combined_filename
-               == os.path.basename(outputdata['path']))
-
-    def test_write_table(self, compilerdata):
-        # (GIVEN)
-        outputcompiler, outputs, outputdata = compilerdata
-
-        logger.info("test `write_table()`")
-
-        # AND combined file does not already exist
-        expected_path = outputdata['path']
-        try:
-            os.remove(expected_path)
-        except OSError:
-            pass
-
-        # WHEN data is read, combined, and written to file
-        outputcompiler.write_table()
-
-        # THEN file should exist at expected path
-        assert(os.path.exists(expected_path))
-
-
-class TestOutputCleaner:
-    @pytest.fixture(scope='function')
-    def output_folder(self, tmpdir):
-        return tmpdir.mkdir('processed')
-
-    def test_get_output_types(self, output_folder):
-        path = output_folder
-        path.mkdir('metrics')
-        path.mkdir('counts')
-        # assert(str(path) == "foo")
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        assert(set(outputcleaner._get_output_types())
-               == set(['metrics', 'counts']))
-
-    def test_get_output_paths(self, output_folder):
-        path = output_folder
-        path.mkdir('QC').mkdir('sample1').ensure('file1.zip')
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        assert(outputcleaner._get_output_paths('QC')
-               == [str(path.join('QC').join('sample1').join('file1.zip'))])
-
-    def test_unzip_output(self, output_folder):
-        path = output_folder
-        zipdir = path.mkdir('zipfolder')
-        zipdir.ensure('file1')
-        zipoutput = shutil.make_archive(str(zipdir), 'zip',
-                                        str(zipdir))
-        shutil.rmtree(str(zipdir))
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        paths = outputcleaner._unzip_output(zipoutput)
-
-        assert('file1' in str(path.listdir()))
-        assert(paths[0] == str(path.join('file1')))
-
-    def test_unnest_output_file(self, output_folder):
-        path = output_folder
-        subdir = path.mkdir('subfolder')
-        nestedoutput = subdir.ensure('file1')
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        outputcleaner._unnest_output(str(nestedoutput))
-
-        assert('subfolder_file1' in str(path.listdir()))
-
-    def test_unnest_output_zip(self, output_folder):
-        path = output_folder
-        subdir = path.mkdir('subfolder')
-        zipdir = subdir.mkdir('zipfolder')
-        nestedoutput = zipdir.ensure('file1')
-        zipoutput = shutil.make_archive(str(zipdir), 'zip',
-                                        str(zipdir))
-        shutil.rmtree(str(zipdir))
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        outputcleaner._unnest_output(str(zipoutput))
-
-        assert('subfolder_file1' in str(path.listdir()))
-
-    def test_recode_output(self, output_folder):
-        path = output_folder
-        qcfile = path.ensure('libID_fcID_fastqc_data.txt')
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        newpath = outputcleaner._recode_output(str(qcfile), 'QC')
-
-        assert(os.path.basename(newpath) == 'libID_fcID_fastqc_qc.txt')
-        assert('libID_fcID_fastqc_qc.txt' in str(path.listdir()))
-
-    def test_clean_outputs(self, output_folder):
-        path = output_folder
-        outdir = path.mkdir('QC')
-
-        lib1dir = outdir.mkdir('lib1_fcID')
-        zip1dir = lib1dir.mkdir('qc1')
-        qc1file = zip1dir.ensure('fastqc_data.txt')
-        zip1out = shutil.make_archive(str(zip1dir), 'zip', str(zip1dir))
-        shutil.rmtree(str(zip1dir))
-
-        lib2dir = outdir.mkdir('lib2_fcID')
-        zip2dir = lib2dir.mkdir('qc1')
-        qc2file = zip2dir.ensure('fastqc_data.txt')
-        zip2out = shutil.make_archive(str(zip2dir), 'zip', str(zip2dir))
-        shutil.rmtree(str(zip2dir))
-
-        outputcleaner = postprocess.OutputCleaner(
-            path=str(path))
-        outputcleaner.clean_outputs()
-
-        assert(len(outdir.listdir()) == 4)
-        assert('lib1_fcID_fastqc_qc.txt' in str(outdir.listdir()))
+        assert (testparser == expected_result)
+
+    def test_read_data(self, tmpdir):
+        mockpath = tmpdir.join('metrics')
+        mockfiledata = [
+            {'mockfilename': 'lib1111_C00000XX_htseq_metrics.txt',
+             'mockcontents': ['__field_1\tsource1_value1\n',
+                              '__field_2\tsource1_value2\n']},
+            {'mockfilename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
+             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+                              'source2_value2\treads aligned in sam file\n']},
+            {'mockfilename': 'lib2222_C00000XX_htseq_metrics.txt',
+             'mockcontents': ['__field_1\tsource1_value1\n',
+                              '__field_2\tsource1_value2\n']},
+            {'mockfilename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
+             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+                              'source2_value2\treads aligned in sam file\n']},
+        ]
+        for m in mockfiledata:
+            mockfile = mockpath.ensure(m['mockfilename'])
+            mockfile.write(''.join(m['mockcontents']))
+
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        stitcher._read_data()
+
+        assert (stitcher.data['metrics'] ==
+                {
+                    'lib1111_C00000XX': [
+                        {'htseq': {'field_1': 'source1_value1',
+                                   'field_2': 'source1_value2'}},
+                        {'tophat_stats': {'fastq_total_reads':
+                                              'source2_value1',
+                                          'reads_aligned_sam':
+                                              'source2_value2'}},
+                    ],
+                    'lib2222_C00000XX': [
+                        {'htseq': {'field_1': 'source1_value1',
+                                   'field_2': 'source1_value2'}},
+                        {'tophat_stats': {'fastq_total_reads':
+                                              'source2_value1',
+                                          'reads_aligned_sam':
+                                              'source2_value2'}},
+                    ],
+                })
+
+    def test_build_table_for_noncount_data(self, tmpdir):
+        mockpath = tmpdir.join('metrics')
+
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        mockdata = {
+            'lib1111_C00000XX': [
+                {'htseq': {'field_1': 'source1_value1',
+                           'field_2': 'source1_value2'}},
+                {'tophat_stats': {'fastq_total_reads':
+                                      'source2_value1',
+                                  'reads_aligned_sam':
+                                      'source2_value2'}},
+            ],
+            'lib2222_C00000XX': [
+                {'htseq': {'field_1': 'source1_value1',
+                           'field_2': 'source1_value2'}},
+                {'tophat_stats': {'fastq_total_reads':
+                                      'source2_value1',
+                                  'reads_aligned_sam':
+                                      'source2_value2'}},
+            ],
+        }
+
+        stitcher.data = {'metrics': mockdata}
+
+        testdata = stitcher._build_table()
+
+        assert (testdata
+                == [
+                    ['libId', 'fastq_total_reads',
+                     'field_1', 'field_2', 'reads_aligned_sam'],
+                    ['lib2222_C00000XX', 'source2_value1',
+                     'source1_value1', 'source1_value2', 'source2_value2'],
+                    ['lib1111_C00000XX', 'source2_value1',
+                     'source1_value1', 'source1_value2', 'source2_value2'],
+                ])
+
+    def test_build_table_for_count_data(self, tmpdir):
+        mockpath = tmpdir.join('counts')
+
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        mockdata = {
+            'lib1111_C00000XX': [
+                {'htseq': pd.DataFrame([['field1', 0], ['field2', 1]],
+                                       columns=['geneName', 'count'])}
+                ],
+            'lib2222_C00000XX': [
+                {'htseq': pd.DataFrame([['field1', 1], ['field2', 0]],
+                                       columns=['geneName', 'count'])}
+                ]
+        }
+
+        stitcher.data = {'counts': mockdata}
+
+        testdata = stitcher._build_table()
+        mockdf = pd.DataFrame(
+            [['field1', 0, 1], ['field2', 1, 0]],
+            columns=['geneName', 'lib1111_C00000XX', 'lib2222_C00000XX']
+        )
+
+        assert all((testdata[k] == mockdf[k]).all() for k in mockdf.keys())
+
+    def test_build_combined_filename(self, tmpdir):
+        mockrun = '161231_INSTID_0001_AC00000XX'
+        mockproject = 'Project_P00-00Processed_161231'
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mockrun)
+                    .mkdir(mockproject)
+                    .mkdir('metrics'))
+
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        testfilename = stitcher._build_combined_filename()
+
+        assert (testfilename == 'P00-00_C00000XX_161231_combined_metrics.csv')
+
+    def test_write_table_for_noncount_data(self, tmpdir):
+        mockrun = '161231_INSTID_0001_AC00000XX'
+        mockproject = 'Project_P00-00Processed_161231'
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mockrun)
+                    .mkdir(mockproject)
+                    .mkdir('metrics'))
+        mockfiledata = [
+            {'mockfilename': 'lib1111_C00000XX_htseq_metrics.txt',
+             'mockcontents': ['__field_1\tsource1_value1\n',
+                              '__field_2\tsource1_value2\n']},
+            {'mockfilename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
+             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+                              'source2_value2\treads aligned in sam file\n']},
+            {'mockfilename': 'lib2222_C00000XX_htseq_metrics.txt',
+             'mockcontents': ['__field_1\tsource1_value1\n',
+                              '__field_2\tsource1_value2\n']},
+            {'mockfilename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
+             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+                              'source2_value2\treads aligned in sam file\n']},
+        ]
+        for m in mockfiledata:
+            mockfile = mockpath.ensure(m['mockfilename'])
+            mockfile.write(''.join(m['mockcontents']))
+
+        mocktablefile = mockpath.join(
+            'P00-00_C00000XX_161231_combined_metrics.csv'
+        )
+        mockcontents = [
+            ','.join(['libId', 'fastq_total_reads',
+                      'field_1', 'field_2', 'reads_aligned_sam\n']),
+            ','.join(['lib2222_C00000XX', 'source2_value1',
+                      'source1_value1', 'source1_value2', 'source2_value2\n']),
+            ','.join(['lib1111_C00000XX', 'source2_value1',
+                      'source1_value1', 'source1_value2', 'source2_value2\n']),
+        ]
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        testtablefile = stitcher.write_table()
+        assert (testtablefile == mocktablefile)
+
+        with open(testtablefile) as f:
+            assert (f.readlines() == mockcontents)
+
+    def test_write_table_for_count_data(self, tmpdir):
+        mockrun = '161231_INSTID_0001_AC00000XX'
+        mockproject = 'Project_P00-00Processed_161231'
+        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mockrun)
+                    .mkdir(mockproject)
+                    .mkdir('counts'))
+        mockfiledata = [
+            {'mockfilename': 'lib1111_C00000XX_htseq_counts.txt',
+             'mockcontents': ['field1\t0\n',
+                              'field2\t1\n']},
+            {'mockfilename': 'lib2222_C00000XX_htseq_counts.txt',
+             'mockcontents': ['field1\t1\n',
+                              'field2\t0\n']},
+        ]
+        for m in mockfiledata:
+            mockfile = mockpath.ensure(m['mockfilename'])
+            mockfile.write(''.join(m['mockcontents']))
+
+        mocktablefile = mockpath.join(
+            'P00-00_C00000XX_161231_combined_counts.csv'
+        )
+        mockcontents = [
+            ','.join(['geneName', 'lib2222_C00000XX', 'lib1111_C00000XX\n']),
+            ','.join(['field1', '1', '0\n']),
+            ','.join(['field2', '0', '1\n']),
+        ]
+        stitcher = postprocess.OutputStitcher(
+            path=str(mockpath)
+        )
+
+        testtablefile = stitcher.write_table()
+        assert (testtablefile == mocktablefile)
+
+        with open(testtablefile) as f:
+            assert (f.readlines() == mockcontents)
+
+
+# class TestOutputCompiler:
+#     @pytest.fixture(
+#         scope='class',
+#         params=[{'runnum': r, 'projectnum': p}
+#                 for r in range(1)
+#                 for p in range(3)])
+#     def compilerdata(self, request, mock_genomics_server):
+#         # GIVEN a OutputCompiler with list of mock 'genomics' server path to
+#         # combined output files
+#         runs = mock_genomics_server['root']['genomics']['illumina']['runs']
+#         rundata = runs[request.param['runnum']]
+#         projects = rundata['processed']['projects']
+#         projectdata = projects[request.param['projectnum']]
+#         outputs = [projectdata[out_type]['combined']
+#                    for out_type in projectdata
+#                    if out_type not in ['path', 'counts', 'combined_summary']]
+#         outputdata = projectdata['combined_summary']
+#
+#         logger.info("[setup] OutputCompiler test instance "
+#                     "for combined output files '{}'"
+#                     .format([f['path'] for f in outputs]))
+#
+#         outputcompiler = postprocess.OutputCompiler(
+#             paths=[f['path'] for f in outputs])
+#
+#         def fin():
+#             logger.info("[teardown] OutputCompiler mock instance")
+#         request.addfinalizer(fin)
+#         return (outputcompiler, outputs, outputdata)
+#
+#     def test_init(self, compilerdata):
+#         # (GIVEN)
+#         outputcompiler, outputs, _ = compilerdata
+#
+#         logger.info("test `__init__()`")
+#
+#         # WHEN object is created
+#
+#         # THEN should have expected paths stored as attribute
+#         assert(len(outputcompiler.paths) == len(outputs))
+#
+#     def test_read_data(self, compilerdata):
+#         # (GIVEN)
+#         outputcompiler, outputs, _ = compilerdata
+#
+#         logger.info("test `_read_data()`")
+#
+#         # WHEN data from individual file paths are read into a list
+#         outputcompiler._read_data()
+#
+#         # THEN data should be stored as list of expected length
+#         assert(len(outputcompiler.data) == len(outputs))
+#
+#     def test_build_table(self, compilerdata):
+#         # (GIVEN)
+#         outputcompiler, outputs, _ = compilerdata
+#
+#         logger.info("test `_build_table()`")
+#
+#         # WHEN data are combined into a single table
+#         table_data = outputcompiler._build_table()
+#
+#         # THEN the table should have the same number of rows (list elements)
+#         # as the first combined output table in the list; and 'libId' should
+#         # only appear once in the header row
+#         assert(len(table_data) == outputs[0]['len_table'])
+#         assert(table_data[0].count('libId') == 1)
+#
+#     def test_build_combined_filename(self, compilerdata):
+#         # (GIVEN)
+#         outputcompiler, outputs, outputdata = compilerdata
+#
+#         logger.info("test `_build_combined_filename()`")
+#
+#         # WHEN path to outputs is parsed to build combined CSV file name
+#         combined_filename = outputcompiler._build_combined_filename()
+#
+#         # THEN combined filename should be correctly formatted
+#         assert(combined_filename
+#                == os.path.basename(outputdata['path']))
+#
+#     def test_write_table(self, compilerdata):
+#         # (GIVEN)
+#         outputcompiler, outputs, outputdata = compilerdata
+#
+#         logger.info("test `write_table()`")
+#
+#         # AND combined file does not already exist
+#         expected_path = outputdata['path']
+#         try:
+#             os.remove(expected_path)
+#         except OSError:
+#             pass
+#
+#         # WHEN data is read, combined, and written to file
+#         outputcompiler.write_table()
+#
+#         # THEN file should exist at expected path
+#         assert(os.path.exists(expected_path))
+#
+#
+# class TestOutputCleaner:
+#     @pytest.fixture(scope='function')
+#     def output_folder(self, tmpdir):
+#         return tmpdir.mkdir('processed')
+#
+#     def test_get_output_types(self, output_folder):
+#         path = output_folder
+#         path.mkdir('metrics')
+#         path.mkdir('counts')
+#         # assert(str(path) == "foo")
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         assert(set(outputcleaner._get_output_types())
+#                == set(['metrics', 'counts']))
+#
+#     def test_get_output_paths(self, output_folder):
+#         path = output_folder
+#         path.mkdir('QC').mkdir('sample1').ensure('file1.zip')
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         assert(outputcleaner._get_output_paths('QC')
+#                == [str(path.join('QC').join('sample1').join('file1.zip'))])
+#
+#     def test_unzip_output(self, output_folder):
+#         path = output_folder
+#         zipdir = path.mkdir('zipfolder')
+#         zipdir.ensure('file1')
+#         zipoutput = shutil.make_archive(str(zipdir), 'zip',
+#                                         str(zipdir))
+#         shutil.rmtree(str(zipdir))
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         paths = outputcleaner._unzip_output(zipoutput)
+#
+#         assert('file1' in str(path.listdir()))
+#         assert(paths[0] == str(path.join('file1')))
+#
+#     def test_unnest_output_file(self, output_folder):
+#         path = output_folder
+#         subdir = path.mkdir('subfolder')
+#         nestedoutput = subdir.ensure('file1')
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         outputcleaner._unnest_output(str(nestedoutput))
+#
+#         assert('subfolder_file1' in str(path.listdir()))
+#
+#     def test_unnest_output_zip(self, output_folder):
+#         path = output_folder
+#         subdir = path.mkdir('subfolder')
+#         zipdir = subdir.mkdir('zipfolder')
+#         nestedoutput = zipdir.ensure('file1')
+#         zipoutput = shutil.make_archive(str(zipdir), 'zip',
+#                                         str(zipdir))
+#         shutil.rmtree(str(zipdir))
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         outputcleaner._unnest_output(str(zipoutput))
+#
+#         assert('subfolder_file1' in str(path.listdir()))
+#
+#     def test_recode_output(self, output_folder):
+#         path = output_folder
+#         qcfile = path.ensure('libID_fcID_fastqc_data.txt')
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         newpath = outputcleaner._recode_output(str(qcfile), 'QC')
+#
+#         assert(os.path.basename(newpath) == 'libID_fcID_fastqc_qc.txt')
+#         assert('libID_fcID_fastqc_qc.txt' in str(path.listdir()))
+#
+#     def test_clean_outputs(self, output_folder):
+#         path = output_folder
+#         outdir = path.mkdir('QC')
+#
+#         lib1dir = outdir.mkdir('lib1_fcID')
+#         zip1dir = lib1dir.mkdir('qc1')
+#         qc1file = zip1dir.ensure('fastqc_data.txt')
+#         zip1out = shutil.make_archive(str(zip1dir), 'zip', str(zip1dir))
+#         shutil.rmtree(str(zip1dir))
+#
+#         lib2dir = outdir.mkdir('lib2_fcID')
+#         zip2dir = lib2dir.mkdir('qc1')
+#         qc2file = zip2dir.ensure('fastqc_data.txt')
+#         zip2out = shutil.make_archive(str(zip2dir), 'zip', str(zip2dir))
+#         shutil.rmtree(str(zip2dir))
+#
+#         outputcleaner = postprocess.OutputCleaner(
+#             path=str(path))
+#         outputcleaner.clean_outputs()
+#
+#         assert(len(outdir.listdir()) == 4)
+#         assert('lib1_fcID_fastqc_qc.txt' in str(outdir.listdir()))

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -601,7 +601,8 @@ class TestOutputCleaner:
 
         # THEN the individual output files previously stored in the
         # zipped archive should now exist in the output type subfolder
-        assert ('outfile1' in str(mock_path.listdir()))
+        assert ('outfile1' in
+                [os.path.basename(str(f)) for f in mock_path.listdir()])
         assert (str(mock_path.join('outfile1')) in test_paths)
 
     def test_unnest_output_file(self, tmpdir):
@@ -647,12 +648,13 @@ class TestOutputCleaner:
         )
 
         # WHEN zipped output files in the subfolder are unnested
-        outputcleaner._unnest_output(str(mock_zippath))
+        outputcleaner._unnest_output(mock_zippath)
 
         # THEN the zipped archives should first be flattened such that
         # individual output files exist directly under the subfolder,
         # and these files should then be unnested and exist directly
         # under the output type folder (labeled as '<subfolder>_<filename>'
+        logger.debug(''.format(mock_path.listdir()))
         assert ('subfolder_outfile1' in
                 [os.path.basename(str(f)) for f in mock_path.listdir()])
 
@@ -668,10 +670,10 @@ class TestOutputCleaner:
             path=str(tmpdir))
 
         # WHEN the output file is renamed according to some predefined rule
-        testpath = outputcleaner._recode_output(str(mock_qcpath), 'QC')
+        test_path = outputcleaner._recode_output(str(mock_qcpath), 'QC')
 
         # THEN the new filename should match the expected result
-        assert (os.path.basename(testpath) == 'libID_fcID_fastqc_qc.txt')
+        assert (os.path.basename(test_path) == 'libID_fcID_fastqc_qc.txt')
         assert ('libID_fcID_fastqc_qc.txt' in
                 [os.path.basename(str(f)) for f in mock_path.listdir()])
 
@@ -696,13 +698,15 @@ class TestOutputCleaner:
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
-            path=str(tmpdir))
+            path=str(tmpdir)
+        )
 
         # WHEN output files for the folder are "cleaned" to resolve unwanted
         # compression, nesting, or deprecated filenames
         outputcleaner.clean_outputs()
 
         # THEN the updated output organization should match expected results
+        logger.debug(''.format(mock_path.listdir()))
         assert (len(mock_path.listdir()) == 4)
         assert ('lib1111_C00000XX_fastqc_qc.txt' in
                 [os.path.basename(str(f)) for f in mock_path.listdir()])

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,8 +1,5 @@
 import logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)
 import os
-import re
 import shutil
 
 import pytest
@@ -10,6 +7,9 @@ import pandas as pd
 
 from bripipetools import postprocess
 from bripipetools import io
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 class TestOutputStitcher:

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -30,11 +30,11 @@ class TestOutputStitcher:
     )
     def test_sniff_output_type(self, tmpdir, test_input, expected_result):
         # GIVEN a path to a folder with output data
-        mockpath = tmpdir.join(test_input)
+        mock_path = tmpdir.join(test_input)
 
         # AND a sticher object is created for that path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN the path is checked to determine output type from a predefined
@@ -58,17 +58,17 @@ class TestOutputStitcher:
     )
     def test_get_parser(self, tmpdir, test_input, expected_result):
         # GIVEN an arbitrary path
-        mockpath = tmpdir.join('')
+        mock_path = tmpdir.join('')
 
         # AND a stitcher object is created for that path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN the io parser class is retrieved for a particular output
         # type and source
-        mocktype, mocksource = test_input
-        testparser = stitcher._get_parser(mocktype, mocksource)
+        mock_type, mock_source = test_input
+        testparser = stitcher._get_parser(mock_type, mock_source)
 
         # THEN the io class should match the expected result
         assert (testparser == expected_result)
@@ -77,31 +77,31 @@ class TestOutputStitcher:
         # GIVEN a path to a folder with output data of type 'metrics'
         # (output type should not matter here, assuming that individual
         # io classes/modules have been tested)
-        mockpath = tmpdir.join('metrics')
+        mock_path = tmpdir.join('metrics')
 
         # AND the folder contains outputs from multiple sources and
         # for multiple samples
-        mockfiledata = [
-            {'mockfilename': 'lib1111_C00000XX_htseq_metrics.txt',
-             'mockcontents': ['__field_1\tsource1_value1\n',
+        mock_filedata = [
+            {'mock_filename': 'lib1111_C00000XX_htseq_metrics.txt',
+             'mock_contents': ['__field_1\tsource1_value1\n',
                               '__field_2\tsource1_value2\n']},
-            {'mockfilename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
-             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+            {'mock_filename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
+             'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
                               'source2_value2\treads aligned in sam file\n']},
-            {'mockfilename': 'lib2222_C00000XX_htseq_metrics.txt',
-             'mockcontents': ['__field_1\tsource1_value1\n',
+            {'mock_filename': 'lib2222_C00000XX_htseq_metrics.txt',
+             'mock_contents': ['__field_1\tsource1_value1\n',
                               '__field_2\tsource1_value2\n']},
-            {'mockfilename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
-             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+            {'mock_filename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
+             'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
                               'source2_value2\treads aligned in sam file\n']},
         ]
-        for m in mockfiledata:
-            mockfile = mockpath.ensure(m['mockfilename'])
-            mockfile.write(''.join(m['mockcontents']))
+        for m in mock_filedata:
+            mock_file = mock_path.ensure(m['mock_filename'])
+            mock_file.write(''.join(m['mock_contents']))
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN all file contents in the folder are read and stored as a dict
@@ -133,17 +133,17 @@ class TestOutputStitcher:
 
     def test_build_table_for_noncount_data(self, tmpdir):
         # GIVEN a path to a folder with output data of type 'metrics'
-        mockpath = tmpdir.join('metrics')
+        mock_path = tmpdir.join('metrics')
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # AND parsed data from output files are stored as a nested dict
         # in the object's 'data' attribute (in the field corresponding to
         # output type)
-        mockdata = {
+        mock_data = {
             'lib1111_C00000XX': [
                 {'htseq': {'field_1': 'source1_value1',
                            'field_2': 'source1_value2'}},
@@ -161,7 +161,7 @@ class TestOutputStitcher:
                                       'source2_value2'}},
             ],
         }
-        stitcher.data = {'metrics': mockdata}
+        stitcher.data = {'metrics': mock_data}
 
         # WHEN all key-value pairs for output data are combined into a
         # single list corresponding to rows of a table for all samples
@@ -185,17 +185,17 @@ class TestOutputStitcher:
         # (methods for combining count data require Pandas dataframe
         # operations, and thus need to be treated differently than
         # other output types)
-        mockpath = tmpdir.join('counts')
+        mock_path = tmpdir.join('counts')
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # AND parsed data from output files are stored as a nested dict
         # in the object's 'data' attribute (in the field corresponding to
         # output type)
-        mockdata = {
+        mock_data = {
             'lib1111_C00000XX': [
                 {'htseq': pd.DataFrame([['field1', 0], ['field2', 1]],
                                        columns=['geneName', 'count'])}
@@ -205,7 +205,7 @@ class TestOutputStitcher:
                                        columns=['geneName', 'count'])}
                 ]
         }
-        stitcher.data = {'counts': mockdata}
+        stitcher.data = {'counts': mock_data}
 
         # WHEN all count data frames merged into a single data frame
         # for all samples, with gene IDs stored in the first column and
@@ -213,26 +213,26 @@ class TestOutputStitcher:
         testdata = stitcher._build_table()
 
         # THEN the combined data frame should match the expected result
-        mockdf = pd.DataFrame(
+        mock_df = pd.DataFrame(
             [['field1', 0, 1], ['field2', 1, 0]],
             columns=['geneName', 'lib1111_C00000XX', 'lib2222_C00000XX']
         )
-        assert all((testdata[k] == mockdf[k]).all() for k in mockdf.keys())
+        assert all((testdata[k] == mock_df[k]).all() for k in mock_df.keys())
 
     def test_build_combined_filename(self, tmpdir):
         # GIVEN a path to a folder with output data of type 'metrics',
         # which exists in a processed project folder at the path
         # '<root>/genomics/Illumina/<run-id>/<project-folder>'
-        mockrun = '161231_INSTID_0001_AC00000XX'
-        mockproject = 'Project_P00-00Processed_161231'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrun)
-                    .mkdir(mockproject)
+        mock_run = '161231_INSTID_0001_AC00000XX'
+        mock_project = 'Project_P00-00Processed_161231'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_run)
+                    .mkdir(mock_project)
                     .mkdir('metrics'))
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN the combined filename is constructed for output data
@@ -247,36 +247,36 @@ class TestOutputStitcher:
         # GIVEN a path to a folder with output data of type 'metrics',
         # which exists in a processed project folder at the path
         # '<root>/genomics/Illumina/<run-id>/<project-folder>'
-        mockrun = '161231_INSTID_0001_AC00000XX'
-        mockproject = 'Project_P00-00Processed_161231'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrun)
-                    .mkdir(mockproject)
+        mock_run = '161231_INSTID_0001_AC00000XX'
+        mock_project = 'Project_P00-00Processed_161231'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_run)
+                    .mkdir(mock_project)
                     .mkdir('metrics'))
 
         # AND the folder contains outputs from multiple sources and
         # for multiple samples
-        mockfiledata = [
-            {'mockfilename': 'lib1111_C00000XX_htseq_metrics.txt',
-             'mockcontents': ['__field_1\tsource1_value1\n',
+        mock_filedata = [
+            {'mock_filename': 'lib1111_C00000XX_htseq_metrics.txt',
+             'mock_contents': ['__field_1\tsource1_value1\n',
                               '__field_2\tsource1_value2\n']},
-            {'mockfilename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
-             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+            {'mock_filename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
+             'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
                               'source2_value2\treads aligned in sam file\n']},
-            {'mockfilename': 'lib2222_C00000XX_htseq_metrics.txt',
-             'mockcontents': ['__field_1\tsource1_value1\n',
+            {'mock_filename': 'lib2222_C00000XX_htseq_metrics.txt',
+             'mock_contents': ['__field_1\tsource1_value1\n',
                               '__field_2\tsource1_value2\n']},
-            {'mockfilename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
-             'mockcontents': ['source2_value1\ttotal reads in fastq file\n'
+            {'mock_filename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
+             'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
                               'source2_value2\treads aligned in sam file\n']},
         ]
-        for m in mockfiledata:
-            mockfile = mockpath.ensure(m['mockfilename'])
-            mockfile.write(''.join(m['mockcontents']))
+        for m in mock_filedata:
+            mock_file = mock_path.ensure(m['mock_filename'])
+            mock_file.write(''.join(m['mock_contents']))
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN combined data across all samples is written as a table
@@ -285,10 +285,10 @@ class TestOutputStitcher:
 
         # THEN the combined table should exist at the expected path and
         # contain the expected contents
-        mocktablefile = mockpath.join(
+        mock_tablefile = mock_path.join(
             'P00-00_C00000XX_161231_combined_metrics.csv'
         )
-        mockcontents = [
+        mock_contents = [
             ','.join(['libId', 'fastq_total_reads',
                       'field_1', 'field_2', 'reads_aligned_sam\n']),
             ','.join(['lib2222_C00000XX', 'source2_value1',
@@ -296,38 +296,38 @@ class TestOutputStitcher:
             ','.join(['lib1111_C00000XX', 'source2_value1',
                       'source1_value1', 'source1_value2', 'source2_value2\n']),
         ]
-        assert (testtablefile == mocktablefile)
+        assert (testtablefile == mock_tablefile)
         with open(testtablefile) as f:
-            assert (f.readlines() == mockcontents)
+            assert (f.readlines() == mock_contents)
 
     def test_write_table_for_count_data(self, tmpdir):
         # GIVEN a path to a folder with output data of type 'counts',
         # which exists in a processed project folder at the path
         # '<root>/genomics/Illumina/<run-id>/<project-folder>'
-        mockrun = '161231_INSTID_0001_AC00000XX'
-        mockproject = 'Project_P00-00Processed_161231'
-        mockpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                    .mkdir(mockrun)
-                    .mkdir(mockproject)
+        mock_run = '161231_INSTID_0001_AC00000XX'
+        mock_project = 'Project_P00-00Processed_161231'
+        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                    .mkdir(mock_run)
+                    .mkdir(mock_project)
                     .mkdir('counts'))
 
         # AND the folder contains outputs from multiple sources and
         # for multiple samples
-        mockfiledata = [
-            {'mockfilename': 'lib1111_C00000XX_htseq_counts.txt',
-             'mockcontents': ['field1\t0\n',
+        mock_filedata = [
+            {'mock_filename': 'lib1111_C00000XX_htseq_counts.txt',
+             'mock_contents': ['field1\t0\n',
                               'field2\t1\n']},
-            {'mockfilename': 'lib2222_C00000XX_htseq_counts.txt',
-             'mockcontents': ['field1\t1\n',
+            {'mock_filename': 'lib2222_C00000XX_htseq_counts.txt',
+             'mock_contents': ['field1\t1\n',
                               'field2\t0\n']},
         ]
-        for m in mockfiledata:
-            mockfile = mockpath.ensure(m['mockfilename'])
-            mockfile.write(''.join(m['mockcontents']))
+        for m in mock_filedata:
+            mock_file = mock_path.ensure(m['mock_filename'])
+            mock_file.write(''.join(m['mock_contents']))
 
         # AND a stitcher object is created for the folder path
         stitcher = postprocess.OutputStitcher(
-            path=str(mockpath)
+            path=str(mock_path)
         )
 
         # WHEN combined data across all samples is written as a table
@@ -336,17 +336,17 @@ class TestOutputStitcher:
 
         # THEN the combined table should exist at the expected path and
         # contain the expected contents
-        mocktablefile = mockpath.join(
+        mock_tablefile = mock_path.join(
             'P00-00_C00000XX_161231_combined_counts.csv'
         )
-        mockcontents = [
+        mock_contents = [
             ','.join(['geneName', 'lib2222_C00000XX', 'lib1111_C00000XX\n']),
             ','.join(['field1', '1', '0\n']),
             ','.join(['field2', '0', '1\n']),
         ]
-        assert (testtablefile == mocktablefile)
+        assert (testtablefile == mock_tablefile)
         with open(testtablefile) as f:
-            assert (f.readlines() == mockcontents)
+            assert (f.readlines() == mock_contents)
 
 
 class TestOutputCompiler:
@@ -359,35 +359,35 @@ class TestOutputCompiler:
     def test_read_data(self, tmpdir):
         # GIVEN a path to a processed project folder at the path
         # '<root>/genomics/Illumina/<run-id>/<project-folder>'
-        mockrun = '161231_INSTID_0001_AC00000XX'
-        mockproject = 'Project_P00-00Processed_161231'
+        mock_run = '161231_INSTID_0001_AC00000XX'
+        mock_project = 'Project_P00-00Processed_161231'
 
         # AND one or more folders with output data of 'summary' types
         # (e.g., metrics, QC, validation), each of which includes a
         # 'combined' table file for its respective type
-        mockpaths = []
-        mockprojectpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                           .mkdir(mockrun)
-                           .mkdir(mockproject))
+        mock_paths = []
+        mock_projectpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                           .mkdir(mock_run)
+                           .mkdir(mock_project))
         for i in range(2):
-            mockpath = mockprojectpath.mkdir('type{}'.format(i))
-            mocktablefile = mockpath.join(
+            mock_path = mock_projectpath.mkdir('type{}'.format(i))
+            mock_tablefile = mock_path.join(
                 'P00-00_C00000XX_161231_combined_type{}.csv'.format(i)
             )
-            mockpaths.append(str(mocktablefile))
-            mockcontents = [
+            mock_paths.append(str(mock_tablefile))
+            mock_contents = [
                 'libId,type{}_field1,type{}_field2\n',
                 'sample1,type{}_sample1_value1,type{}_sample1_value2\n',
                 'sample2,type{}_sample2_value1,type{}_sample2_value2\n',
             ]
 
-            mocktablefile.write(
-                ''.join([line.format(i+1, i+1) for line in mockcontents])
+            mock_tablefile.write(
+                ''.join([line.format(i+1, i+1) for line in mock_contents])
             )
 
         # AND a compiler object is created for the project folder path
         compiler = postprocess.OutputCompiler(
-            paths=mockpaths
+            paths=mock_paths
         )
 
         # WHEN data from the combined table for each type is read and
@@ -397,7 +397,7 @@ class TestOutputCompiler:
         # THEN the resulting list stored in the object's 'data' attribute
         # should include a list for each combined table, with each item
         # representing a row in a table as a list of column values
-        mockdata = [
+        mock_data = [
             [
                 ['libId', 'type1_field1', 'type1_field2'],
                 ['sample1','type1_sample1_value1', 'type1_sample1_value2'],
@@ -409,7 +409,7 @@ class TestOutputCompiler:
                 ['sample2', 'type2_sample2_value1', 'type2_sample2_value2'],
             ],
         ]
-        assert (compiler.data == mockdata)
+        assert (compiler.data == mock_data)
 
     def test_build_table(self):
         # GIVEN a compiler object, created for an arbitrary list of paths
@@ -419,7 +419,7 @@ class TestOutputCompiler:
 
         # AND parsed data from combined output table files are stroed in the
         # object's 'data' attribute
-        mockdata = [
+        mock_data = [
             [
                 ['libId', 'type1_field1', 'type1_field2'],
                 ['sample1','type1_sample1_value1', 'type1_sample1_value2'],
@@ -431,7 +431,7 @@ class TestOutputCompiler:
                 ['sample2', 'type2_sample2_value1', 'type2_sample2_value2'],
             ],
         ]
-        compiler.data = mockdata
+        compiler.data = mock_data
 
         # WHEN combined data from each type are merged into a list
         # representing representing rows for an overall project summary table
@@ -439,7 +439,7 @@ class TestOutputCompiler:
 
         # THEN the merged rows should contain sample (library) IDs in the
         # first column, and all other columns from different output types
-        mocktabledata = [
+        mock_tabledata = [
             ['libId', 'type1_field1', 'type1_field2',
              'type2_field1', 'type2_field2'],
             ['sample1', 'type1_sample1_value1', 'type1_sample1_value2',
@@ -447,19 +447,19 @@ class TestOutputCompiler:
             ['sample2', 'type1_sample2_value1', 'type1_sample2_value2',
              'type2_sample2_value1', 'type2_sample2_value2'],
         ]
-        assert (testdata == mocktabledata)
+        assert (testdata == mock_tabledata)
 
     def test_build_combined_filename(self):
         # GIVEN a list one or more paths to 'combined' table files for
         # arbitrary output types
-        mockpaths = [
+        mock_paths = [
             'P00-00_C00000XX_161231_combined_type{}.csv'.format(i)
             for i in range(2)
             ]
 
         # AND a compiler object is created for the paths
         compiler = postprocess.OutputCompiler(
-            paths=mockpaths
+            paths=mock_paths
         )
 
         # WHEN the filename is constructed for the merged table with
@@ -474,35 +474,35 @@ class TestOutputCompiler:
     def test_write_table(self, tmpdir):
         # GIVEN a path to a processed project folder at the path
         # '<root>/genomics/Illumina/<run-id>/<project-folder>'
-        mockrun = '161231_INSTID_0001_AC00000XX'
-        mockproject = 'Project_P00-00Processed_161231'
+        mock_run = '161231_INSTID_0001_AC00000XX'
+        mock_project = 'Project_P00-00Processed_161231'
 
         # AND one or more folders with output data of 'summary' types
         # (e.g., metrics, QC, validation), each of which includes a
         # 'combined' table file for its respective type
-        mockpaths = []
-        mockprojectpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                           .mkdir(mockrun)
-                           .mkdir(mockproject))
+        mock_paths = []
+        mock_projectpath = (tmpdir.mkdir('genomics').mkdir('Illumina')
+                           .mkdir(mock_run)
+                           .mkdir(mock_project))
         for i in range(2):
-            mockpath = mockprojectpath.mkdir('type{}'.format(i))
-            mocktablefile = mockpath.join(
+            mock_path = mock_projectpath.mkdir('type{}'.format(i))
+            mock_tablefile = mock_path.join(
                 'P00-00_C00000XX_161231_combined_type{}.csv'.format(i)
             )
-            mockpaths.append(str(mocktablefile))
-            mockcontents = [
+            mock_paths.append(str(mock_tablefile))
+            mock_contents = [
                 'libId,type{}_field1,type{}_field2\n',
                 'sample1,type{}_sample1_value1,type{}_sample1_value2\n',
                 'sample2,type{}_sample2_value1,type{}_sample2_value2\n',
             ]
 
-            mocktablefile.write(
-                ''.join([line.format(i+1, i+1) for line in mockcontents])
+            mock_tablefile.write(
+                ''.join([line.format(i+1, i+1) for line in mock_contents])
             )
 
         # AND a compiler object is created for the project folder path
         compiler = postprocess.OutputCompiler(
-            paths=mockpaths
+            paths=mock_paths
         )
 
         # WHEN compiled data across all summary output types is written
@@ -511,10 +511,10 @@ class TestOutputCompiler:
 
         # THEN the combined table should exist at the expected path and
         # contain the expected contents
-        mocktablefile = mockprojectpath.join(
+        mock_tablefile = mock_projectpath.join(
             'P00-00_C00000XX_161231_combined_summary-data.csv'
         )
-        mockcontents = [
+        mock_contents = [
             ','.join(['libId', 'type1_field1', 'type1_field2',
                       'type2_field1', 'type2_field2\n']),
             ','.join(['sample1',
@@ -524,9 +524,9 @@ class TestOutputCompiler:
                       'type1_sample2_value1', 'type1_sample2_value2',
                       'type2_sample2_value1', 'type2_sample2_value2\n']),
         ]
-        assert (testtablefile == mocktablefile)
+        assert (testtablefile == mock_tablefile)
         with open(testtablefile) as f:
-            assert (f.readlines() == mockcontents)
+            assert (f.readlines() == mock_contents)
 
 
 class TestOutputCleaner:
@@ -538,8 +538,8 @@ class TestOutputCleaner:
 
     def test_get_output_types(self, tmpdir):
         # GIVEN a path to a folder with output data
-        mockfolders = ['counts', 'metrics', 'QC', 'alignments', 'logs']
-        for outfolder in mockfolders:
+        mock_folders = ['counts', 'metrics', 'QC', 'alignments', 'logs']
+        for outfolder in mock_folders:
             tmpdir.mkdir(outfolder)
 
         # AND a cleaner object is created for that path
@@ -549,10 +549,10 @@ class TestOutputCleaner:
 
         # WHEN the path is checked to determine output type from a predefined
         # set of options
-        testtypes = cleaner._get_output_types()
+        test_types = cleaner._get_output_types()
 
         # THEN the assigned output type should match the expected result
-        assert (set(testtypes) == set(mockfolders))
+        assert (set(test_types) == set(mock_folders))
 
     @pytest.mark.parametrize(
         'test_input', ['counts', 'metrics', 'QC', 'alignments', 'logs']
@@ -561,11 +561,11 @@ class TestOutputCleaner:
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type contains one or
         # more files
-        mockpath = tmpdir.mkdir(test_input)
-        mockpaths = []
+        mock_path = tmpdir.mkdir(test_input)
+        mock_paths = []
         for i in range(2):
-            mockfile = mockpath.ensure('outfile{}'.format(i))
-            mockpaths.append(str(mockfile))
+            mock_file = mock_path.ensure('outfile{}'.format(i))
+            mock_paths.append(str(mock_file))
 
         # AND a cleaner object is created for that path
         cleaner = postprocess.OutputCleaner(
@@ -573,23 +573,23 @@ class TestOutputCleaner:
         )
 
         # WHEN full paths are collected for all output files
-        testpaths = cleaner._get_output_paths(test_input)
+        test_paths = cleaner._get_output_paths(test_input)
 
         # THEN list of paths should match expected results
-        assert (testpaths == mockpaths)
+        assert (set(test_paths) == set(mock_paths))
 
     def test_unzip_output(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type
-        mockpath = tmpdir.mkdir('metrics')
+        mock_path = tmpdir.mkdir('metrics')
 
         # AND the folder contains a zipped archive with one or more
         # output files
-        mockzipdir = mockpath.mkdir('zipfolder')
-        mockzipdir.ensure('outfile1')
-        mockzippath = shutil.make_archive(str(mockzipdir), 'zip',
-                                          str(mockzipdir))
-        shutil.rmtree(str(mockzipdir))
+        mock_zipdir = mock_path.mkdir('zipfolder')
+        mock_zipdir.ensure('outfile1')
+        mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
+                                          str(mock_zipdir))
+        shutil.rmtree(str(mock_zipdir))
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
@@ -597,22 +597,22 @@ class TestOutputCleaner:
         )
 
         # WHEN the zipped archive is uncompressed
-        testpaths = outputcleaner._unzip_output(mockzippath)
+        test_paths = outputcleaner._unzip_output(mock_zippath)
 
         # THEN the individual output files previously stored in the
         # zipped archive should now exist in the output type subfolder
-        assert ('outfile1' in str(mockpath.listdir()))
-        assert (testpaths[0] == str(mockpath.join('outfile1')))
+        assert ('outfile1' in str(mock_path.listdir()))
+        assert (str(mock_path.join('outfile1')) in test_paths)
 
     def test_unnest_output_file(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type
-        mockpath = tmpdir.mkdir('metrics')
+        mock_path = tmpdir.mkdir('metrics')
 
         # AND the folder contains another subfolder with one or more
         # output files
-        mocksubdir = mockpath.mkdir('subfolder')
-        mocknestpath = mocksubdir.ensure('outfile1')
+        mock_subdir = mock_path.mkdir('subfolder')
+        mock_nestpath = mock_subdir.ensure('outfile1')
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
@@ -620,25 +620,26 @@ class TestOutputCleaner:
         )
 
         # WHEN output files in the subfolder are unnested
-        outputcleaner._unnest_output(str(mocknestpath))
+        outputcleaner._unnest_output(str(mock_nestpath))
 
         # THEN the files should exist directly under the output type
         # folder and be labeled in the form '<subfolder>_<filename>'
-        assert ('subfolder_outfile1' in str(mockpath.listdir()))
+        assert ('subfolder_outfile1' in
+                [os.path.basename(str(f)) for f in mock_path.listdir()])
 
     def test_unnest_output_zip(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type
-        mockpath = tmpdir.mkdir('metrics')
+        mock_path = tmpdir.mkdir('metrics')
 
         # AND the folder contains another subfolder with one or more
         # zipped archives than in turn contain one or more output files
-        mocksubdir = mockpath.mkdir('subfolder')
-        mockzipdir = mocksubdir.mkdir('zipfolder')
-        mockzipdir.ensure('outfile1')
-        mockzippath = shutil.make_archive(str(mockzipdir), 'zip',
-                                          str(mockzipdir))
-        shutil.rmtree(str(mockzipdir))
+        mock_subdir = mock_path.mkdir('subfolder')
+        mock_zipdir = mock_subdir.mkdir('zipfolder')
+        mock_zipdir.ensure('outfile1')
+        mock_zippath = shutil.make_archive(str(mock_zipdir), 'zip',
+                                          str(mock_zipdir))
+        shutil.rmtree(str(mock_zipdir))
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
@@ -646,50 +647,50 @@ class TestOutputCleaner:
         )
 
         # WHEN zipped output files in the subfolder are unnested
-        outputcleaner._unnest_output(str(mockzippath))
+        outputcleaner._unnest_output(str(mock_zippath))
 
         # THEN the zipped archives should first be flattened such that
         # individual output files exist directly under the subfolder,
         # and these files should then be unnested and exist directly
         # under the output type folder (labeled as '<subfolder>_<filename>'
-        assert('subfolder_outfile1' in str(mockpath.listdir()))
+        assert('subfolder_outfile1' in str(mock_path.listdir()))
 
     def test_recode_output(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type, which contains
         # an output file
-        mockpath = tmpdir.mkdir('QC')
-        mockqcpath = mockpath.ensure('libID_fcID_fastqc_data.txt')
+        mock_path = tmpdir.mkdir('QC')
+        mock_qcpath = mock_path.ensure('libID_fcID_fastqc_data.txt')
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
             path=str(tmpdir))
 
         # WHEN the output file is renamed according to some predefined rule
-        testpath = outputcleaner._recode_output(str(mockqcpath), 'QC')
+        testpath = outputcleaner._recode_output(str(mock_qcpath), 'QC')
 
         # THEN the new filename should match the expected result
         assert (os.path.basename(testpath) == 'libID_fcID_fastqc_qc.txt')
-        assert ('libID_fcID_fastqc_qc.txt' in str(mockpath.listdir()))
+        assert ('libID_fcID_fastqc_qc.txt' in str(mock_path.listdir()))
 
     def test_clean_outputs(self, tmpdir):
         # GIVEN a path to a folder with output data, and a subfolder
         # corresponding to a particular output type
-        mockpath = tmpdir.mkdir('QC')
+        mock_path = tmpdir.mkdir('QC')
 
         # AND the output type folder contains output files for one or more
         # samples with various levels of compression and nesting
-        mockoutputdata = {
+        mock_outputdata = {
             1: 'lib1111_C00000XX',
             2: 'lib2222_C00000XX'
         }
         for i in range(2):
-            mocksampledir = mockpath.mkdir(mockoutputdata[i+1])
-            mockzipdir = mocksampledir.mkdir('qc{}'.format(i))
-            mockzipdir.ensure('fastqc_data.txt')
-            shutil.make_archive(str(mockzipdir), 'zip',
-                                str(mockzipdir))
-            shutil.rmtree(str(mockzipdir))
+            mock_sampledir = mock_path.mkdir(mock_outputdata[i+1])
+            mock_zipdir = mock_sampledir.mkdir('qc{}'.format(i))
+            mock_zipdir.ensure('fastqc_data.txt')
+            shutil.make_archive(str(mock_zipdir), 'zip',
+                                str(mock_zipdir))
+            shutil.rmtree(str(mock_zipdir))
 
         # AND a cleaner object is created for the path
         outputcleaner = postprocess.OutputCleaner(
@@ -700,6 +701,6 @@ class TestOutputCleaner:
         outputcleaner.clean_outputs()
 
         # THEN the updated output organization should match expected results
-        assert (len(mockpath.listdir()) == 4)
+        assert (len(mock_path.listdir()) == 4)
         assert ('lib1111_C00000XX_fastqc_qc.txt'
-                in str(mockpath.listdir()))
+                in str(mock_path.listdir()))


### PR DESCRIPTION
Continuing to replace convoluted test setup (with lots of example file dependencies) with more self-contained and clearly documented tests: this time updating more complicated tests for `annotation`, `postprocess`, and `dbify` modules.