### PR TITLE
Reorg parsing methods

### DIFF
--- a/bripipetools/dbify/flowcellrun.py
+++ b/bripipetools/dbify/flowcellrun.py
@@ -2,9 +2,8 @@
 Class for importing data from a sequencing run into GenLIMS as new objects.
 """
 import logging
-import os
 
-from .. import util
+from .. import parsing
 from .. import genlims
 from .. import annotation
 
@@ -23,18 +22,11 @@ class FlowcellRunImporter(object):
         self.path = path
         self.db = db
 
-    def _parse_flowcell_path(self):
-        """
-        Return 'genomics' root and run ID based on directory path.
-        """
-        return {'genomics_root': util.matchdefault('.*(?=genomics)', self.path),
-                'run_id': os.path.basename(self.path.rstrip('/'))}
-
     def _collect_flowcellrun(self):
         """
         Collect FlowcellRun object for flowcell run.
         """
-        path_items = self._parse_flowcell_path()
+        path_items = parsing.parse_flowcell_path(self.path)
         logger.info("collecting info for flowcell run {}"
                     .format(path_items['run_id']))
 
@@ -48,7 +40,7 @@ class FlowcellRunImporter(object):
         """
         Collect list of SequencedLibrary objects for flowcell run.
         """
-        path_items = self._parse_flowcell_path()
+        path_items = parsing.parse_flowcell_path(self.path)
         logger.info("collecting sequenced libraries for flowcell run {}"
                     .format(path_items['run_id']))
 

--- a/bripipetools/dbify/workflowbatch.py
+++ b/bripipetools/dbify/workflowbatch.py
@@ -2,9 +2,8 @@
 Class for importing data from a processing batch into GenLIMS as new objects.
 """
 import logging
-import os
 
-from .. import util
+from .. import parsing
 from .. import genlims
 from .. import annotation
 
@@ -23,18 +22,11 @@ class WorkflowBatchImporter(object):
         self.path = path
         self.db = db
 
-    def _parse_batch_file_path(self):
-        """
-        Return 'genomics' root and batch file name based on directory path.
-        """
-        return {'genomics_root': util.matchdefault('.*(?=genomics)', self.path),
-                'workflowbatch_filename': os.path.basename(self.path)}
-
     def _collect_workflowbatch(self):
         """
         Collect WorkflowBatch object for flowcell run.
         """
-        path_items = self._parse_batch_file_path()
+        path_items = parsing.parse_batch_file_path(self.path)
         logger.info("collecting info for workflow batch file {}"
                     .format(path_items['workflowbatch_filename']))
 
@@ -48,7 +40,7 @@ class WorkflowBatchImporter(object):
         """
         Collect list of ProcessedLibrary objects for flowcell run.
         """
-        path_items = self._parse_batch_file_path()
+        path_items = parsing.parse_batch_file_path(self.path)
         logger.info("collecting sequenced libraries for workflow batch file {}"
                     .format(path_items['workflowbatch_filename']))
 

--- a/bripipetools/io/workflowbatch.py
+++ b/bripipetools/io/workflowbatch.py
@@ -3,7 +3,6 @@ Classes for reading, parsing, and writing workflow batch submit files for
 Globus Galaxy.
 """
 import logging
-import re
 
 from collections import OrderedDict
 

--- a/bripipetools/io/workflowbatch.py
+++ b/bripipetools/io/workflowbatch.py
@@ -7,6 +7,8 @@ import re
 
 from collections import OrderedDict
 
+from .. import parsing
+
 logger = logging.getLogger(__name__)
 
 
@@ -84,24 +86,6 @@ class WorkflowBatchFile(object):
                            [self._locate_batch_name_line()])
         return batch_name_line.strip().split('\t')[-1]
 
-    def _parse_param(self, param):
-        """
-        Break parameter into components.
-        """
-        param_tag = param.split('##')[0]
-        if re.search('annotation', param_tag):
-            param_type = 'annotation'
-        elif re.search('in', param_tag):
-            param_type = 'input'
-        elif re.search('out', param_tag):
-            param_type = 'output'
-        else:
-            param_type = 'sample'
-
-        return {'tag': param_tag,
-                'type': param_type,
-                'name': param.split('::')[-1]}
-
     def get_params(self):
         """
         Return the parameters defined for the current workflow.
@@ -111,7 +95,7 @@ class WorkflowBatchFile(object):
             for each parameter.
         """
         param_line = self.data['raw'][self._locate_param_line()]
-        return OrderedDict((idx, self._parse_param(p))
+        return OrderedDict((idx, parsing.parse_workflow_param(p))
                            for idx, p
                            in enumerate(param_line.strip().split('\t')))
 

--- a/bripipetools/parsing/__init__.py
+++ b/bripipetools/parsing/__init__.py
@@ -13,4 +13,4 @@ from .gencore import (get_project_label, parse_project_label,
                       parse_batch_file_path)
 from .illumina import (get_flowcell_id, parse_flowcell_run_id,
                        parse_fastq_filename)
-from .processing import (parse_batch_name)
+from .processing import (parse_batch_name, parse_output_filename)

--- a/bripipetools/parsing/__init__.py
+++ b/bripipetools/parsing/__init__.py
@@ -8,6 +8,8 @@ Core (via GenLIMS).
 
 Depends on the ``util`` module.
 """
-from .illumina import (get_project_label, parse_project_label,
-                       get_library_id, get_flowcell_id, parse_flowcell_run_id,
-                       parse_fastq_filename, parse_batch_name)
+from .gencore import (get_project_label, parse_project_label,
+                      get_library_id)
+from .illumina import (get_flowcell_id, parse_flowcell_run_id,
+                       parse_fastq_filename)
+from .processing import (parse_batch_name)

--- a/bripipetools/parsing/__init__.py
+++ b/bripipetools/parsing/__init__.py
@@ -13,4 +13,5 @@ from .gencore import (get_project_label, parse_project_label,
                       parse_batch_file_path)
 from .illumina import (get_flowcell_id, parse_flowcell_run_id,
                        parse_fastq_filename)
-from .processing import (parse_batch_name, parse_output_filename)
+from .processing import (parse_batch_name, parse_workflow_param,
+                         parse_output_filename)

--- a/bripipetools/parsing/__init__.py
+++ b/bripipetools/parsing/__init__.py
@@ -9,7 +9,8 @@ Core (via GenLIMS).
 Depends on the ``util`` module.
 """
 from .gencore import (get_project_label, parse_project_label,
-                      get_library_id)
+                      get_library_id, parse_flowcell_path,
+                      parse_batch_file_path)
 from .illumina import (get_flowcell_id, parse_flowcell_run_id,
                        parse_fastq_filename)
 from .processing import (parse_batch_name)

--- a/bripipetools/parsing/gencore.py
+++ b/bripipetools/parsing/gencore.py
@@ -1,0 +1,53 @@
+import logging
+import datetime
+
+from .. import util
+
+logger = logging.getLogger(__name__)
+
+
+def get_project_label(string):
+    """
+    Return a Genomics Core project label matched in input string.
+
+    :type string: str
+    :param string: any string
+
+    :rtype: str
+    :return: Genomics Core project label (e.g., P00-0) substring or
+        empty string, if no match found
+    """
+    return util.matchdefault('P+[0-9]+(-[0-9]+){,1}', string)
+
+
+def parse_project_label(project_label):
+    """
+    Parse a Genomics Core project label (e.g., P00-0) and return
+    individual components indicating project ID and subproject ID.
+
+    :type project_label: str
+    :param project_label: String following Genomics Core convention for
+        project labels, P<project ID>-<subproject ID>
+
+    :rtype: dict
+    :return: a dict with fields for 'project_id' and 'subproject_id'
+    """
+    project_id = int(util.matchdefault('(?<=P)[0-9]+', project_label))
+    subproject_id = int(util.matchdefault('(?<=-)[0-9]+', project_label))
+
+    return {'project_id': project_id, 'subproject_id': subproject_id}
+
+
+def get_library_id(string):
+    """
+    Return library ID matched in input string.
+
+    :type string: str
+    :param string: any string that might contain a library ID of the
+        format 'lib1234'
+
+    :rtype: str
+    :return: the matching substring representing the library ID or an
+        empty string ('') if no match found
+    """
+    return util.matchdefault('lib[1-9]+[0-9]*', string)

--- a/bripipetools/parsing/gencore.py
+++ b/bripipetools/parsing/gencore.py
@@ -1,5 +1,5 @@
 import logging
-import datetime
+import os
 
 from .. import util
 
@@ -51,3 +51,22 @@ def get_library_id(string):
         empty string ('') if no match found
     """
     return util.matchdefault('lib[1-9]+[0-9]*', string)
+
+
+def parse_flowcell_path(flowcell_path):
+    """
+    Return 'genomics' root and run ID based on directory path.
+    """
+    # TODO: raise some sort of exception, if path doesn't end in valid run id
+    return {'genomics_root': util.matchdefault('.*(?=genomics)', flowcell_path),
+            'run_id': os.path.basename(flowcell_path.rstrip('/'))}
+
+
+def parse_batch_file_path(batchfile_path):
+    """
+    Return 'genomics' root and batch file name based on directory path.
+    """
+    return {'genomics_root': util.matchdefault('.*(?=genomics)',
+                                               batchfile_path),
+            'workflowbatch_filename': os.path.basename(batchfile_path)}
+

--- a/bripipetools/parsing/illumina.py
+++ b/bripipetools/parsing/illumina.py
@@ -6,53 +6,6 @@ from .. import util
 logger = logging.getLogger(__name__)
 
 
-def get_project_label(string):
-    """
-    Return a Genomics Core project label matched in input string.
-
-    :type string: str
-    :param string: any string
-
-    :rtype: str
-    :return: Genomics Core project label (e.g., P00-0) substring or
-        empty string, if no match found
-    """
-    return util.matchdefault('P+[0-9]+(-[0-9]+){,1}', string)
-
-
-def parse_project_label(project_label):
-    """
-    Parse a Genomics Core project label (e.g., P00-0) and return
-    individual components indicating project ID and subproject ID.
-
-    :type project_label: str
-    :param project_label: String following Genomics Core convention for
-        project labels, P<project ID>-<subproject ID>
-
-    :rtype: dict
-    :return: a dict with fields for 'project_id' and 'subproject_id'
-    """
-    project_id = int(util.matchdefault('(?<=P)[0-9]+', project_label))
-    subproject_id = int(util.matchdefault('(?<=-)[0-9]+', project_label))
-
-    return {'project_id': project_id, 'subproject_id': subproject_id}
-
-
-def get_library_id(string):
-    """
-    Return library ID matched in input string.
-
-    :type string: str
-    :param string: any string that might contain a library ID of the
-        format 'lib1234'
-
-    :rtype: str
-    :return: the matching substring representing the library ID or an
-        empty string ('') if no match found
-    """
-    return util.matchdefault('lib[1-9]+[0-9]*', string)
-
-
 def get_flowcell_id(string):
     """
     Return flowcell ID.
@@ -133,15 +86,3 @@ def parse_fastq_filename(path):
             'sample_number': sample_num}
 
 
-def parse_batch_name(batch_name):
-    """
-    Parse batch name indicated in workflow batch submit file and
-    return individual components indicating date, list of project
-    labels, and flowcell ID.
-    """
-    name_parts = batch_name.split('_')
-    date = datetime.datetime.strptime(name_parts.pop(0), '%y%m%d')
-
-    fc_id = name_parts.pop(-1)
-
-    return {'date': date, 'projects': name_parts, 'flowcell_id': fc_id}

--- a/bripipetools/parsing/processing.py
+++ b/bripipetools/parsing/processing.py
@@ -21,23 +21,26 @@ def parse_batch_name(batch_name):
 
     return {'date': date, 'projects': name_parts, 'flowcell_id': fc_id}
 
-# def _parse_param(self, param):
-#     """
-#     Break parameter into components.
-#     """
-#     param_tag = param.split('##')[0]
-#     if re.search('annotation', param_tag):
-#         param_type = 'annotation'
-#     elif re.search('in', param_tag):
-#         param_type = 'input'
-#     elif re.search('out', param_tag):
-#         param_type = 'output'
-#     else:
-#         param_type = 'sample'
-#
-#     return {'tag': param_tag,
-#             'type': param_type,
-#             'name': param.split('::')[-1]}
+
+def parse_workflow_param(param):
+    """
+    Parse workflow parameter into components indicating tag,
+    type, and name.
+    """
+    param_tag = param.split('##')[0]
+    if re.search('annotation', param_tag):
+        param_type = 'annotation'
+    elif re.search('in', param_tag):
+        param_type = 'input'
+    elif re.search('out', param_tag):
+        param_type = 'output'
+    else:
+        param_type = 'sample'
+
+    return {'tag': param_tag,
+            'type': param_type,
+            'name': param.split('::')[-1]}
+
 
 def parse_output_filename(output_path):
     """

--- a/bripipetools/parsing/processing.py
+++ b/bripipetools/parsing/processing.py
@@ -3,8 +3,6 @@ import datetime
 import os
 import re
 
-from .. import util
-
 logger = logging.getLogger(__name__)
 
 

--- a/bripipetools/parsing/processing.py
+++ b/bripipetools/parsing/processing.py
@@ -1,0 +1,20 @@
+import logging
+import datetime
+
+from .. import util
+
+logger = logging.getLogger(__name__)
+
+
+def parse_batch_name(batch_name):
+    """
+    Parse batch name indicated in workflow batch submit file and
+    return individual components indicating date, list of project
+    labels, and flowcell ID.
+    """
+    name_parts = batch_name.split('_')
+    date = datetime.datetime.strptime(name_parts.pop(0), '%y%m%d')
+
+    fc_id = name_parts.pop(-1)
+
+    return {'date': date, 'projects': name_parts, 'flowcell_id': fc_id}

--- a/bripipetools/parsing/processing.py
+++ b/bripipetools/parsing/processing.py
@@ -1,5 +1,7 @@
 import logging
 import datetime
+import os
+import re
 
 from .. import util
 
@@ -18,3 +20,43 @@ def parse_batch_name(batch_name):
     fc_id = name_parts.pop(-1)
 
     return {'date': date, 'projects': name_parts, 'flowcell_id': fc_id}
+
+# def _parse_param(self, param):
+#     """
+#     Break parameter into components.
+#     """
+#     param_tag = param.split('##')[0]
+#     if re.search('annotation', param_tag):
+#         param_type = 'annotation'
+#     elif re.search('in', param_tag):
+#         param_type = 'input'
+#     elif re.search('out', param_tag):
+#         param_type = 'output'
+#     else:
+#         param_type = 'sample'
+#
+#     return {'tag': param_tag,
+#             'type': param_type,
+#             'name': param.split('::')[-1]}
+
+def parse_output_filename(output_path):
+    """
+    Parse output name indicated by parameter tag in output file
+    return individual components indicating processed library ID,
+    output source, and type.
+    """
+    output_filename = os.path.basename(output_path)
+    output_name = os.path.splitext(output_filename)[0]
+    name_parts = output_name.split('_')
+
+    output_type = name_parts.pop(-1)
+    source = name_parts.pop(-1)
+    if (len(name_parts) <= 2
+        and not re.search('(picard|tophat)', name_parts[-1])):
+        sample_id = '_'.join(name_parts)
+    else:
+        source = '-'.join([name_parts.pop(-1), source])
+        sample_id = '_'.join(name_parts)
+
+    return {'sample_id': sample_id, 'type': output_type,
+            'source': source}

--- a/bripipetools/postprocess/stitching.py
+++ b/bripipetools/postprocess/stitching.py
@@ -52,38 +52,20 @@ class OutputStitcher(object):
                 and re.search(output_filetypes[output_type],
                               os.path.splitext(f)[-1])]
 
-    def _parse_output_filename(self, output_filename):
-        """
-        Parse output name indicated by parameter tag in output file
-        return individual components indicating processed library ID,
-        output source, and type.
-        """
-        output_filename = os.path.basename(output_filename)
-        output_name = os.path.splitext(output_filename)[0]
-        name_parts = output_name.split('_')
-        output_type = name_parts.pop(-1)
-        source = name_parts.pop(-1)
-        if len(name_parts) <= 2:
-            proclib_id = '_'.join(name_parts)
-        else:
-            source = '_'.join([name_parts.pop(-1), source])
-            proclib_id = '_'.join(name_parts)
-
-        return {'proclib_id': proclib_id, 'type': output_type,
-                'source': source}
-
     def _get_parser(self, output_type, output_source):
         """
         Return the appropriate parser for the current output file.
         """
-        parsers = {'metrics': {'htseq': getattr(io, 'HtseqMetricsFile'),
-                               'picard_rnaseq': getattr(io, 'PicardMetricsFile'),
-                               'picard_markdups': getattr(io, 'PicardMetricsFile'),
-                               'picard_align': getattr(io, 'PicardMetricsFile'),
-                               'tophat_stats': getattr(io, 'TophatStatsFile')},
-                   'qc': {'fastqc': getattr(io, 'FastQCFile')},
-                   'counts': {'htseq': getattr(io, 'HtseqCountsFile')},
-                   'validation': {'sexcheck': getattr(io, 'SexcheckFile')}}
+        parsers = {
+            'metrics': {'htseq': getattr(io, 'HtseqMetricsFile'),
+                        'picard-rnaseq': getattr(io, 'PicardMetricsFile'),
+                        'picard-markdups': getattr(io, 'PicardMetricsFile'),
+                        'picard-align': getattr(io, 'PicardMetricsFile'),
+                        'tophat-stats': getattr(io, 'TophatStatsFile')},
+            'qc': {'fastqc': getattr(io, 'FastQCFile')},
+            'counts': {'htseq': getattr(io, 'HtseqCountsFile')},
+            'validation': {'sexcheck': getattr(io, 'SexcheckFile')}
+        }
         logger.debug("matched parser {} for output type {} and source {}"
                      .format(parsers[output_type][output_source],
                              output_type, output_source))
@@ -98,8 +80,11 @@ class OutputStitcher(object):
 
         for o in outputs:
             logger.debug("parsing output file {}".format(o))
-            out_items = self._parse_output_filename(o)
-            out_source, out_type, proclib_id = out_items.values()
+            out_items = parsing.parse_output_filename(o)
+            proclib_id = out_items['sample_id']
+            out_type = out_items['type']
+            out_source = out_items['source']
+
             logger.debug("storing data from {} in {} {}".format(
                 out_source, proclib_id, out_type))
             out_parser = self._get_parser(out_type, out_source)(path=o)

--- a/tests/test_dbify.py
+++ b/tests/test_dbify.py
@@ -26,28 +26,6 @@ class TestFlowcellRunImporter:
     Tests methods for the `FlowcellRunImporter` class in the
     `bripipetools.dbify.flowcellrun` module.
     """
-    def test_parse_flowcell_path(self, mock_db):
-        # GIVEN a path to a flowcell run folder and a connection to a
-        # database in which a document corresponding to the flowcell run
-        # may or may not exist
-        mock_root = '/mnt/'
-        mock_id = '161231_INSTID_0001_AC00000XX'
-        mock_path = '{}genomics/Illumina/{}'.format(mock_root, mock_id)
-
-        # AND an importer object is created for the path
-        importer = dbify.FlowcellRunImporter(
-            path=mock_path,
-            db=mock_db
-        )
-
-        # WHEN the path argument is parsed to find the 'genomics' root
-        # and flowcell run ID
-        test_items = importer._parse_flowcell_path()
-
-        # THEN the 'genomics' root and run ID should match the mock server
-        assert (test_items['genomics_root'] == mock_root)
-        assert (test_items['run_id'] == mock_id)
-
     def test_collect_flowcellrun(self, mock_db):
         # GIVEN a path to a flowcell run folder and a connection to a
         # database in which a document corresponding to the flowcell run
@@ -209,30 +187,6 @@ class TestWorkflowBatchImporter:
     Tests methods for the `WorkflowBatchImporter` class in the
     `bripipetools.dbify.workflowbatch` module.
     """
-    def test_parse_batch_file_path(self, mock_db, tmpdir):
-        # GIVEN a path to a workflow batch file and a connection to a
-        # database in which a document corresponding to the workflow batch
-        # may or may not exist
-        mock_id = '161231_INSTID_0001_AC00000XX'
-        mock_path = (tmpdir.mkdir('genomics').mkdir('Illumina')
-                     .mkdir(mock_id).mkdir('globus_batch_submission'))
-        mock_filename = '161231_P00-00_C00000XX_workflow-name.txt'
-        mock_path = mock_batchfile(mock_filename, mock_path)
-
-        # AND an importer object is created for the path
-        importer = dbify.WorkflowBatchImporter(
-            path=mock_path,
-            db=mock_db
-        )
-
-        # WHEN the path argument is parsed to find the 'genomics' root
-        # and workflow batch file name
-        test_items = importer._parse_batch_file_path()
-
-        # THEN the 'genomics' root and run ID should match the mock server
-        assert (test_items['genomics_root'].rstrip('/') == str(tmpdir))
-        assert (test_items['workflowbatch_filename'] == mock_filename)
-
     def test_collect_workflowbatch(self, mock_db, tmpdir):
         # GIVEN a path to a workflow batch file and a connection to a
         # database in which a document corresponding to the workflow batch

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -830,34 +830,6 @@ class TestWorkflowBatchFile:
         # THEN should be expected result
         assert (batch_name == 'DATE_P00-00_FLOWCELL')
 
-    @pytest.mark.parametrize(
-        'test_input, expected_result',
-        [
-            ('SampleName', {'tag': 'SampleName',
-                            'type': 'sample',
-                            'name': 'SampleName'}),
-            ('annotation_tag##_::_::param_name', {'tag': 'annotation_tag',
-                                                  'type': 'annotation',
-                                                  'name': 'param_name'}),
-            ('in_tag##_::_::_::param_name', {'tag': 'in_tag',
-                                             'type': 'input',
-                                             'name': 'param_name'}),
-            ('out_tag##_::_::_::param_name', {'tag': 'out_tag',
-                                              'type': 'output',
-                                              'name': 'param_name'}),
-        ]
-    )
-    def test_parse_param(self, test_input, expected_result):
-        # GIVEN an io class object for an arbitrary file
-        testfile = io.WorkflowBatchFile(path='')
-
-        # WHEN a workflow parameter formatted 'tag##unused::details::param_name'
-        # is parsed to collect its component parts and classified as 'sample',
-        # 'input', 'output', or 'annotation'
-
-        # THEN parsed dict should match expected result
-        assert (testfile._parse_param(test_input) == expected_result)
-
     def test_get_params(self):
         # GIVEN some file content representing the typical format of a
         # a sample parameter table, parameters names are listed in the

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -224,33 +224,78 @@ class TestProcessing:
     def test_parse_batch_name(self):
         # GIVEN any state
 
-        # WHEN parsing batch name from workflow batch file
+        # WHEN parsing batch name from workflow batch file with name
+        # formatted as '<date>_<project1>_..._<projectN>_<fc_id>'
         test_items = parsing.parse_batch_name('160929_P109-1_P14-12_C6VG0ANXX')
 
-        # THEN items should be in a dict with fields for date (string),
+        # THEN items should be in a dict with fields for date (datetime),
         # project labels (list of strings), and flowcell ID (string)
         assert (test_items['date'] == datetime.datetime(2016, 9, 29, 0, 0))
         assert (test_items['projects'] == ['P109-1', 'P14-12'])
         assert (test_items['flowcell_id'] == 'C6VG0ANXX')
 
-    # TODO: _parse_output_filename() from `postprocess.stitching`
+    @pytest.mark.parametrize(
+        'mock_path, expected_result',
+        [
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/alignments/'
+                     'lib1111_C00000XX_tophat_alignments.bam'),
+                    {'sample_id': 'lib1111_C00000XX',
+                     'type': 'alignments',
+                     'source': 'tophat'}
+            ),
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/alignments/'
+                     'lib1111_tophat_alignments.bam'),
+                    {'sample_id': 'lib1111',
+                     'type': 'alignments',
+                     'source': 'tophat'}
+            ),
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/metrics/'
+                     'lib1111_picard_markdups_metrics.html'),
+                    {'sample_id': 'lib1111',
+                     'type': 'metrics',
+                     'source': 'picard-markdups'}
+            ),
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/metrics/'
+                     'lib1111_C00000XX_picard_markdups_metrics.html'),
+                    {'sample_id': 'lib1111_C00000XX',
+                     'type': 'metrics',
+                     'source': 'picard-markdups'}
+            ),
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/metrics/'
+                     'lib1111_C00000XX_picard-markdups_metrics.html'),
+                    {'sample_id': 'lib1111_C00000XX',
+                     'type': 'metrics',
+                     'source': 'picard-markdups'}
+            ),
+            (
+                    ('/mnt/genomics/Illumina/161231_INSTID_0001_AC00000XX'
+                     'Project_P1-1Processed/metrics/'
+                     'lib1111_picard-markdups_metrics.html'),
+                    {'sample_id': 'lib1111',
+                     'type': 'metrics',
+                     'source': 'picard-markdups'}
+            ),
+        ]
+    )
+    def test_parse_output_filename(self, mock_path, expected_result):
 
-#     def test_parse_output_name_onepart_source(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_parse_output_name()`, one-part source")
-#
-#         # WHEN parsing output name from workflow batch parameter, and the
-#         # source name has one parts (i.e., 'tophat')
-#         output_items = annotator._parse_output_name(
-#             'tophat_alignments_bam_out')
-#
-#         # THEN output items should be a dictionary including fields for
-#         # name, type, and source
-#         assert(output_items['name'] == 'tophat_alignments_bam')
-#         assert(output_items['type'] == 'alignments')
-#         assert(output_items['source'] == 'tophat')
+        # WHEN parsing output name from workflow batch parameter, and the
+        # source name has one parts (i.e., 'tophat')
+        test_items = parsing.parse_output_filename(mock_path)
+
+        # THEN output items should be a dictionary including fields for
+        # name, type, and source
+        assert (test_items == expected_result)
 #
 #     def test_parse_output_name_twopart_source(self, annotatordata):
 #         # (GIVEN)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -5,10 +5,11 @@ import pytest
 from bripipetools import parsing
 
 
-class TestIllumina:
+class TestGencore:
     """
-    Tests methods for extracting identifiers and other information
-    related to Illumina sequencing technology from strings and paths.
+    Tests methods in the `bripipetools.parsing.gencore` module for
+    extracting identifiers and other information related to BRI
+    Genomics Core samples and data from strings and paths.
     """
     @pytest.mark.parametrize(
         'test_input, expected_result',
@@ -59,6 +60,13 @@ class TestIllumina:
         # match found)
         assert (parsing.get_library_id(test_input) == expected_result)
 
+
+class TestIllumina:
+    """
+    Tests methods in the `bripipetools.parsing.illumina` module for
+    extracting identifiers and other information related to Illumina
+    sequencing technology from strings and paths.
+    """
     def test_get_flowcell_id(self):
         # GIVEN any state
 
@@ -143,6 +151,13 @@ class TestIllumina:
         assert (fastq_items['read_id'] == 'R1')
         assert (fastq_items['sample_number'] == 1)
 
+
+class TestProcessing:
+    """
+    Tests methods in the `bripipetools.parsing.processing` module for
+    extracting identifiers and other information related to processing
+    workflows, batches, steps, and parameters from strings and paths.
+    """
     def test_parse_batch_name(self):
         # GIVEN any state
 
@@ -151,9 +166,9 @@ class TestIllumina:
 
         # THEN items should be in a dict with fields for date (string),
         # project labels (list of strings), and flowcell ID (string)
-        assert(batch_items['date'] == datetime.datetime(2016, 9, 29, 0, 0))
-        assert(batch_items['projects'] == ['P109-1', 'P14-12'])
-        assert(batch_items['flowcell_id'] == 'C6VG0ANXX')
+        assert (batch_items['date'] == datetime.datetime(2016, 9, 29, 0, 0))
+        assert (batch_items['projects'] == ['P109-1', 'P14-12'])
+        assert (batch_items['flowcell_id'] == 'C6VG0ANXX')
 
 #
 #     def test_parse_output_name_onepart_source(self, annotatordata):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -235,6 +235,34 @@ class TestProcessing:
         assert (test_items['flowcell_id'] == 'C6VG0ANXX')
 
     @pytest.mark.parametrize(
+        'mock_param, expected_result',
+        [
+            ('SampleName', {'tag': 'SampleName',
+                            'type': 'sample',
+                            'name': 'SampleName'}),
+            ('annotation_tag##_::_::param_name', {'tag': 'annotation_tag',
+                                                  'type': 'annotation',
+                                                  'name': 'param_name'}),
+            ('in_tag##_::_::_::param_name', {'tag': 'in_tag',
+                                             'type': 'input',
+                                             'name': 'param_name'}),
+            ('out_tag##_::_::_::param_name', {'tag': 'out_tag',
+                                              'type': 'output',
+                                              'name': 'param_name'}),
+        ]
+    )
+    def test_parse_workflow_param(self, mock_param, expected_result):
+        # GIVEN any state
+
+        # WHEN a workflow parameter formatted 'tag##unused::details::param_name'
+        # is parsed to collect its component parts and classified as 'sample',
+        # 'input', 'output', or 'annotation'
+        test_items = parsing.parse_workflow_param(mock_param)
+
+        # THEN parsed dict should match expected result
+        assert (test_items == expected_result)
+
+    @pytest.mark.parametrize(
         'mock_path, expected_result',
         [
             (
@@ -296,20 +324,3 @@ class TestProcessing:
         # THEN output items should be a dictionary including fields for
         # name, type, and source
         assert (test_items == expected_result)
-#
-#     def test_parse_output_name_twopart_source(self, annotatordata):
-#         # (GIVEN)
-#         annotator, _, _ = annotatordata
-#
-#         logger.info("test `_parse_output_name()`, two-part source")
-#
-#         # WHEN parsing output name from workflow batch parameter, and the
-#         # source name has two parts (i.e., 'picard_rnaseq')
-#         output_items = annotator._parse_output_name(
-#             'picard_rnaseq_metrics_html_out')
-#
-#         # THEN output items should be a dictionary including fields for
-#         # name, type, and source
-#         assert(output_items['name'] == 'picard_rnaseq_metrics_html')
-#         assert(output_items['type'] == 'metrics')
-#         assert(output_items['source'] == 'picard_rnaseq')

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -60,6 +60,9 @@ class TestGencore:
         # match found)
         assert (parsing.get_library_id(test_input) == expected_result)
 
+    # TODO: _parse_flowcell_path() from `dbify.flowcellrun`
+    # TODO: _parse_batch_file_path() from `dbifiy.workflowbatch`
+
 
 class TestIllumina:
     """
@@ -170,7 +173,8 @@ class TestProcessing:
         assert (batch_items['projects'] == ['P109-1', 'P14-12'])
         assert (batch_items['flowcell_id'] == 'C6VG0ANXX')
 
-#
+    # TODO: _parse_output_filename() from `postprocess.stitching`
+
 #     def test_parse_output_name_onepart_source(self, annotatordata):
 #         # (GIVEN)
 #         annotator, _, _ = annotatordata

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -47,10 +47,10 @@ class TestOutputStitcher:
         'test_input, expected_result',
         [
             (('metrics', 'htseq'), getattr(io, 'HtseqMetricsFile')),
-            (('metrics', 'picard_rnaseq'), getattr(io, 'PicardMetricsFile')),
-            (('metrics', 'picard_markdups'), getattr(io, 'PicardMetricsFile')),
-            (('metrics', 'picard_align'), getattr(io, 'PicardMetricsFile')),
-            (('metrics', 'tophat_stats'), getattr(io, 'TophatStatsFile')),
+            (('metrics', 'picard-rnaseq'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'picard-markdups'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'picard-align'), getattr(io, 'PicardMetricsFile')),
+            (('metrics', 'tophat-stats'), getattr(io, 'TophatStatsFile')),
             (('qc', 'fastqc'), getattr(io, 'FastQCFile')),
             (('counts', 'htseq'), getattr(io, 'HtseqCountsFile')),
             (('validation', 'sexcheck'), getattr(io, 'SexcheckFile'))
@@ -84,16 +84,16 @@ class TestOutputStitcher:
         mock_filedata = [
             {'mock_filename': 'lib1111_C00000XX_htseq_metrics.txt',
              'mock_contents': ['__field_1\tsource1_value1\n',
-                              '__field_2\tsource1_value2\n']},
+                               '__field_2\tsource1_value2\n']},
             {'mock_filename': 'lib1111_C00000XX_tophat_stats_metrics.txt',
              'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
-                              'source2_value2\treads aligned in sam file\n']},
+                               'source2_value2\treads aligned in sam file\n']},
             {'mock_filename': 'lib2222_C00000XX_htseq_metrics.txt',
              'mock_contents': ['__field_1\tsource1_value1\n',
-                              '__field_2\tsource1_value2\n']},
+                               '__field_2\tsource1_value2\n']},
             {'mock_filename': 'lib2222_C00000XX_tophat_stats_metrics.txt',
              'mock_contents': ['source2_value1\ttotal reads in fastq file\n'
-                              'source2_value2\treads aligned in sam file\n']},
+                               'source2_value2\treads aligned in sam file\n']},
         ]
         for m in mock_filedata:
             mock_file = mock_path.ensure(m['mock_filename'])
@@ -116,7 +116,7 @@ class TestOutputStitcher:
                     'lib1111_C00000XX': [
                         {'htseq': {'field_1': 'source1_value1',
                                    'field_2': 'source1_value2'}},
-                        {'tophat_stats': {'fastq_total_reads':
+                        {'tophat-stats': {'fastq_total_reads':
                                               'source2_value1',
                                           'reads_aligned_sam':
                                               'source2_value2'}},
@@ -124,7 +124,7 @@ class TestOutputStitcher:
                     'lib2222_C00000XX': [
                         {'htseq': {'field_1': 'source1_value1',
                                    'field_2': 'source1_value2'}},
-                        {'tophat_stats': {'fastq_total_reads':
+                        {'tophat-stats': {'fastq_total_reads':
                                               'source2_value1',
                                           'reads_aligned_sam':
                                               'source2_value2'}},


### PR DESCRIPTION
Move several methods for parsing various strings or paths from `dbify`, `postprocess`, and `io` packages into more appropriate `parsing` package. Additionally, separating `illumina`-specific parsing methods from those related to Genomics Core or processing workflows, now in `gencore` and `processing` parsing modules, respectively.