### PR TITLE
Add sample submit

### DIFF
--- a/bripipetools/__main__.py
+++ b/bripipetools/__main__.py
@@ -130,26 +130,50 @@ def main(verbosity):
                     "or folder paths (not a flowcell run) from which "
                     "a workflow batch is to be created (note: options "
                     "'sort-samples' and 'num-samples' will be ignored)"))
+@click.option('--out-dir', '-o', default=os.path.curdir,
+              help=("for input manifest, folder where outputs are to "
+                    "be saved; default is current directory"))
 @click.argument('path')
 def submit(endpoint, workflow_dir, all_workflows, sort_samples, num_samples,
-           path):
+           manifest, out_dir, path):
     """
-    Prepare batch submission for unaligned samples from a flowcell run.
+    Prepare batch submission for unaligned samples from a flowcell run
+    or from a list of paths in a manifest file.
     """
-    logger.info("Creating batches for unaligned samples and projects "
-                "from flowcell run '{}'".format(path))
-    logger.info("... will search '{}' for workflow template options"
-                .format(workflow_dir))
-    logger.info("... destination endpoint for processing outputs is '{}'"
-                .format(endpoint))
-    submitter = bripipetools.submission.FlowcellSubmissionBuilder(
-        path=path,
-        endpoint=endpoint,
-        db=DB,
-        workflow_dir=workflow_dir,
-        all_workflows=all_workflows
-    )
-    submit_paths = submitter.run(sort=sort_samples, num_samples=num_samples)
+    if not manifest:
+        logger.info("Creating batches for unaligned samples and projects "
+                    "from flowcell run '{}'".format(path))
+        logger.info("... will search '{}' for workflow template options"
+                    .format(workflow_dir))
+        logger.info("... destination endpoint for processing outputs is '{}'"
+                    .format(endpoint))
+        submitter = bripipetools.submission.FlowcellSubmissionBuilder(
+            path=path,
+            endpoint=endpoint,
+            db=DB,
+            workflow_dir=workflow_dir,
+            all_workflows=all_workflows
+        )
+        submit_paths = submitter.run(sort=sort_samples,
+                                     num_samples=num_samples)
+    else:
+        logger.info("Creating batche unaligned samples listed in '{}'"
+                    .format(path))
+        logger.info("... will search '{}' for workflow template options"
+                    .format(workflow_dir))
+        logger.info("... destination endpoint for processing outputs is '{}'"
+                    .format(endpoint))
+        logger.info("... outputs to be saved in '{}'"
+                    .format(out_dir))
+        submitter = bripipetools.submission.SampleSubmissionBuilder(
+            manifest=path,
+            out_dir=out_dir,
+            endpoint=endpoint,
+            workflow_dir=workflow_dir,
+            all_workflows=all_workflows
+        )
+        submit_paths = submitter.run()
+
     print("\nPrepared the following workflow batch submit files:\n"
           "(ready for upload to Globus Genomics)\n")
     for p in submit_paths:

--- a/bripipetools/__main__.py
+++ b/bripipetools/__main__.py
@@ -125,6 +125,11 @@ def main(verbosity):
 @click.option('--num-samples', '-n', default=None, type=int,
               help=("restrict the number of samples submitted for each "
                     "project on the flowcell"))
+@click.option('--manifest', '-m', is_flag=True,
+              help=("indicates that input path is a manifest of sample "
+                    "or folder paths (not a flowcell run) from which "
+                    "a workflow batch is to be created (note: options "
+                    "'sort-samples' and 'num-samples' will be ignored)"))
 @click.argument('path')
 def submit(endpoint, workflow_dir, all_workflows, sort_samples, num_samples,
            path):

--- a/bripipetools/submission/__init__.py
+++ b/bripipetools/submission/__init__.py
@@ -2,3 +2,4 @@
 from .batchparameterize import BatchParameterizer
 from .batchcreate import BatchCreator
 from .flowcellsubmit import FlowcellSubmissionBuilder
+from .samplesubmit import SampleSubmissionBuilder

--- a/bripipetools/submission/flowcellsubmit.py
+++ b/bripipetools/submission/flowcellsubmit.py
@@ -60,6 +60,7 @@ class FlowcellSubmissionBuilder(object):
                      .format(unaligned_path))
         self.project_paths = [os.path.join(unaligned_path, p)
                               for p in self.annotator.get_projects()]
+        self.project_paths.sort()
         logger.debug("found the following unaligned projects: {}"
                      .format([os.path.basename(os.path.normpath(f))
                               for f in self.project_paths]))
@@ -75,12 +76,18 @@ class FlowcellSubmissionBuilder(object):
         batch_map = {}
         while continue_assign:
             print("\nFound the following projects: "
-                  "[current workflows selected]")
+                  "[current workflows (w) and builds (b) selected]")
             for i, p in enumerate(self.project_paths):
-                workflow_nums = [w for w, k in enumerate(workflow_opts)
-                                 if p in batch_map.get(k, [])]
+                opts_p = map(lambda x: x[0],
+                             filter(lambda x: p in x[1], batch_map.items()))
+
+                w_p = ['w:{}'.format([w for w, k in enumerate(workflow_opts)
+                                      if k == opt[0]][0])
+                       for opt in opts_p]
+                b_p = ['b:{}'.format(opt[1]) for opt in opts_p]
+
                 print("   {} : {} {}".format(i, os.path.basename(p),
-                                             str(workflow_nums)))
+                                             zip(w_p, b_p)))
 
             p_i = raw_input("\nType the number of the project you wish "
                             "to select or hit enter to finish: ")

--- a/bripipetools/submission/samplesubmit.py
+++ b/bripipetools/submission/samplesubmit.py
@@ -62,12 +62,12 @@ class SampleSubmissionBuilder(object):
 
         for j, w in enumerate(workflow_opts):
             print("   {} : {}".format(j, os.path.basename(w)))
-        w_j = raw_input("\nSelect the number of the workflow to use:")
+        w_j = raw_input("\nSelect the number of the workflow to use: ")
         selected_workflow = workflow_opts[int(w_j)]
 
         for j, b in enumerate(build_opts):
             print("   {} : {}".format(j, b))
-        b_j = raw_input("\nSelect the genome build to use:")
+        b_j = raw_input("\nSelect the genome build to use: ")
         selected_build = build_opts[int(b_j)]
 
         batch_key = (selected_workflow, selected_build)

--- a/bripipetools/submission/samplesubmit.py
+++ b/bripipetools/submission/samplesubmit.py
@@ -1,0 +1,101 @@
+import logging
+import os
+import re
+
+from . import BatchCreator
+
+logger = logging.getLogger(__name__)
+
+
+class SampleSubmissionBuilder(object):
+    """
+    Prepares workflow batch submissions for a list of sample paths
+    or folders of sample paths.
+    """
+    def __init__(self, manifest, out_dir, endpoint, workflow_dir=None,
+                 all_workflows=True, tag=None):
+        logger.debug("creating `SampleSubmissionBuilder` instance")
+        self.manifest = manifest
+
+        self.out_dir = out_dir
+        self.endpoint = endpoint
+        if workflow_dir is not None:
+            self.workflow_dir = workflow_dir
+        self.all_workflows = all_workflows
+
+        if tag is None:
+            self.tag = ''
+        else:
+            self.tag = tag
+
+    def _read_paths(self):
+        with open(self.manifest) as f:
+            self.paths = [p.rstrip() for p in f.readlines()]
+
+    def get_workflow_options(self, optimized_only=True):
+        logger.debug("collecting workflow templates from '{}'"
+                     .format(self.workflow_dir))
+        workflow_opts = [os.path.join(self.workflow_dir, f)
+                         for f in os.listdir(self.workflow_dir)
+                         if 'Galaxy-API' not in f
+                         and not re.search('^\.', f)]
+        workflow_opts.sort()
+        logger.debug("found the following workflow options: {}"
+                     .format([os.path.basename(f) for f in workflow_opts]))
+
+        if optimized_only:
+            workflow_opts = [f for f in workflow_opts
+                             if re.search('optimized', f)]
+            logger.debug("keeping only optimized workflows: {}"
+                         .format([os.path.basename(f) for f in workflow_opts]))
+
+        return workflow_opts
+
+    def _assign_workflow(self):
+        if not hasattr(self, 'paths'):
+            self._read_paths()
+
+        workflow_opts = self.get_workflow_options(
+            optimized_only=not self.all_workflows
+        )
+        build_opts = ['GRCh38', 'NCBIM37', 'hg19', 'mm10', 'mm9']
+
+        for j, w in enumerate(workflow_opts):
+            print("   {} : {}".format(j, os.path.basename(w)))
+        w_j = raw_input("\nSelect the number of the workflow to use:")
+        selected_workflow = workflow_opts[int(w_j)]
+
+        for j, b in enumerate(build_opts):
+            print("   {} : {}".format(j, b))
+        b_j = raw_input("\nSelect the genome build to use:")
+        selected_build = build_opts[int(b_j)]
+
+        batch_key = (selected_workflow, selected_build)
+        batch_map = {batch_key: self.paths}
+        logger.debug("current state of batch map: {}"
+                     .format(batch_map))
+
+        self.batch_map = batch_map
+
+    def run(self):
+        if not hasattr(self, 'batch_map'):
+            self._assign_workflow()
+
+        batch_paths = []
+        for batchkey, paths in self.batch_map.items():
+            workflow, build = batchkey
+            logger.info("Building batch for workflow '{}' and build '{}'"
+                        .format(os.path.basename(workflow), build))
+            creator = BatchCreator(
+                paths=paths,
+                workflow_template=workflow,
+                endpoint=self.endpoint,
+                base_dir=self.out_dir,
+                group_tag=self.tag,
+                build=build
+            )
+            batch_paths.append(creator.create_batch())
+            logger.debug("workflow batch parameters saved in file '{}'"
+                         .format(batch_paths[-1]))
+
+        return batch_paths

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -720,7 +720,7 @@ class TestFlowcellSubmissionBuilder:
 
         mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
         mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
-        mock_workflowopts = [str(mock_workflowdir.mkdir(w))
+        mock_workflowopts = [str(mock_workflowdir.ensure(w))
                              for w in mock_workflows]
         mock_workflowopts.sort()
 
@@ -743,7 +743,7 @@ class TestFlowcellSubmissionBuilder:
 
         mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
         mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
-        mock_workflowopts = [str(mock_workflowdir.mkdir(w))
+        mock_workflowopts = [str(mock_workflowdir.ensure(w))
                              for w in mock_workflows
                              if re.search('optimized', w)]
         mock_workflowopts.sort()
@@ -899,3 +899,136 @@ class TestFlowcellSubmissionBuilder:
         assert (len([l for l in test_contents
                      if re.search('^lib', l)])
                 == 2)
+
+
+class TestSampleSubmissionBuilder:
+    """
+
+    """
+    def test_read_paths(self, tmpdir):
+        mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
+        mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
+        mock_workflowopts = [str(mock_workflowdir.ensure(w))
+                             for w in mock_workflows]
+        mock_workflowopts.sort()
+
+        # mock_filename = 'optimized_workflow_1.txt'
+        # mock_file = mock_template(mock_filename, tmpdir)
+
+        mock_samples = ['lib1111-11111111', 'lib2222-22222222']
+        mock_paths = []
+        for s in mock_samples:
+            samplepath = tmpdir.mkdir(s)
+            mock_paths.append(str(samplepath))
+            samplepath.ensure('sample-name_S001_L001_R1_001.fastq.gz')
+            samplepath.ensure('sample-name_S001_L002_R1_001.fastq.gz')
+
+        mock_manifest = tmpdir.join('manifest.txt')
+        mock_manifest.write('\n'.join(mock_paths))
+
+        builder = submission.SampleSubmissionBuilder(
+            manifest=str(mock_manifest),
+            out_dir=str(tmpdir),
+            endpoint='',
+            workflow_dir=str(mock_workflowdir)
+        )
+
+        builder._read_paths()
+
+        assert (builder.paths == mock_paths)
+
+    def test_get_workflow_options_for_all_workflows(self, tmpdir):
+        mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
+        mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
+        mock_workflowopts = [str(mock_workflowdir.ensure(w))
+                             for w in mock_workflows]
+        mock_workflowopts.sort()
+
+        builder = submission.SampleSubmissionBuilder(
+            manifest='',
+            out_dir=str(tmpdir),
+            endpoint='',
+            workflow_dir=str(mock_workflowdir)
+        )
+
+        test_workflowopts = builder.get_workflow_options(optimized_only=False)
+
+        assert (test_workflowopts == mock_workflowopts)
+
+    def test_assign_workflow(self, tmpdir):
+        mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
+        mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
+        mock_workflowopts = [str(mock_workflowdir.ensure(w))
+                             for w in mock_workflows]
+        mock_workflowopts.sort()
+
+        mock_buildopts = ['GRCh38', 'NCBIM37', 'mm10']
+
+        mock_samples = ['lib1111-11111111', 'lib2222-22222222']
+        mock_paths = []
+        for s in mock_samples:
+            samplepath = tmpdir.mkdir(s)
+            mock_paths.append(str(samplepath))
+            samplepath.ensure('sample-name_S001_L001_R1_001.fastq.gz')
+            samplepath.ensure('sample-name_S001_L002_R1_001.fastq.gz')
+
+        builder = submission.SampleSubmissionBuilder(
+            manifest='',
+            out_dir=str(tmpdir),
+            endpoint='',
+            workflow_dir=str(mock_workflowdir)
+        )
+
+        builder.paths = mock_paths
+
+        with mock.patch('__builtin__.raw_input',
+                        side_effect=iter(["0", "0"])):
+            builder._assign_workflow()
+
+        mock_batchkey = (mock_workflowopts[0], mock_buildopts[0])
+        assert (builder.batch_map == {mock_batchkey: mock_paths})
+
+    def test_run(self, tmpdir):
+        mock_workflowdir = tmpdir.mkdir('galaxy_workflows')
+        mock_workflows = ['workflow1.txt', 'optimized_workflow1.txt']
+        mock_workflowopts = [mock_template(w, mock_workflowdir)
+                             for w in mock_workflows
+                             if re.search('optimized', w)]
+        mock_workflowopts.sort()
+
+        mock_buildopts = ['GRCh38', 'NCBIM37', 'mm10']
+
+        mock_samples = ['lib1111-11111111', 'lib2222-22222222']
+        mock_paths = []
+        for s in mock_samples:
+            samplepath = tmpdir.mkdir(s)
+            mock_paths.append(str(samplepath))
+            samplepath.ensure('sample-name_S001_L001_R1_001.fastq.gz')
+            samplepath.ensure('sample-name_S001_L002_R1_001.fastq.gz')
+
+        builder = submission.SampleSubmissionBuilder(
+            manifest='',
+            out_dir=str(tmpdir),
+            endpoint='',
+            workflow_dir=str(mock_workflowdir)
+        )
+
+        mock_batchkey = (mock_workflowopts[0], mock_buildopts[0])
+        builder.batch_map = {mock_batchkey: mock_paths}
+
+        test_batchpaths = builder.run()
+
+        with open(test_batchpaths[0]) as f:
+            test_contents = f.readlines()
+        logger.debug("{}".format(test_contents))
+
+        mock_date = datetime.date.today().strftime("%y%m%d")
+        mock_batchpaths = [os.path.join(
+            str(tmpdir),
+            '{}__optimized_workflow1_GRCh38.txt'.format(mock_date)
+        )]
+
+        assert (test_batchpaths == mock_batchpaths)
+        assert (len([l for l in test_contents
+                     if re.search('^lib', l)])
+                == 32)

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1031,4 +1031,4 @@ class TestSampleSubmissionBuilder:
         assert (test_batchpaths == mock_batchpaths)
         assert (len([l for l in test_contents
                      if re.search('^lib', l)])
-                == 32)
+                == 2)


### PR DESCRIPTION
Provides a new wrapper around `batchcreate` that is a bit more flexible than `flowcellsubmit` - allows for submission of an arbitrary set of samples based on a list of file paths (or folders containing file paths). Also fixes some formatting with submission prompts.